### PR TITLE
Memory safety + import dissolve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md
+
+Guidance for Claude (and any AI assistant) working in this repo.
+
+## Where to put what
+
+- **Code comments**: explain the "what" and the technical "why" (hidden constraints, non-obvious invariants, references to a learning.md section). Keep them tight - a sentence or two max. Never write multi-paragraph comment blocks.
+- **Incident write-ups, post-mortems, historical narrative, dated decision logs**: go in [learning.md](learning.md), not in source files. Code comments rot; learning.md is the durable record. When a fix is informed by a past incident, the comment should *point at* the learning.md section (e.g. `# See learning.md "Parent-side memory in the pipeline"`), not retell the story.
+- **Operator-facing tuning notes**: belong inline near the relevant `config.ini` key, but kept short (one sentence on what it does, plus a pointer to learning.md if there's a known failure mode behind it).
+
+## Why this rule exists
+
+Long historical comments inside source files turn every diff review into a history lesson, age badly as the code changes around them, and duplicate learning.md without the structure (date, rule, why, how to apply, non-regression). Keep code comments about *the code*; keep learning.md about *what we learned*.
+
+## learning.md format
+
+Each entry is a level-2 section dated by the day the lesson landed:
+
+```
+## <Topic> (YYYY-MM-DD)
+
+- Rule: <the one-line takeaway, imperative>
+- Why: <root cause + brief incident context, including measurements/numbers if relevant>
+- How to apply: <concrete trigger - "when editing X, check Y">
+- Non-regression guarantee: <only if the fix preserves prior behaviour by default>
+```
+
+Append, do not rewrite history. Mark a previous entry as superseded inline if a newer entry overrides it.
+
+## Pipeline-specific gotchas worth knowing about
+
+- The processing pipeline (`code/processing_internal.py`) has been bitten more than once by parent-process memory blow-ups in the gaps *between* worker pools. Per-pool watchdogs, per-stage worker caps, and pre-flight checks all only run inside `Pool(...)` blocks - parent-side reads/merges between pools are unguarded. There is now a process-lifetime sentinel (`_start_lifetime_panic_watchdog`) as a backstop, but it costs the entire run's progress when it fires; do not rely on it to catch sloppy parent-side allocations. Before adding any read in the parent, check whether it materialises a known-large dataset (`tbl_stacked`, `tbl_flat`). See learning.md "Parent-side memory in the pipeline".
+- `read_parquet_or_empty()` materialises the entire dataset including geometries. Read its docstring before calling it on anything other than small, known-bounded tables.

--- a/code/asset_manage.py
+++ b/code/asset_manage.py
@@ -572,6 +572,7 @@ def load_settings() -> dict:
         "import_simplify_geometries": _bool_setting(d.get("import_simplify_geometries", "false"), False),
         "import_simplify_tolerance_m": float(d.get("import_simplify_tolerance_m", "1.0")),
         "import_simplify_preserve_topology": _bool_setting(d.get("import_simplify_preserve_topology", "true"), True),
+        "import_dissolve_grid_cells": _bool_setting(d.get("import_dissolve_grid_cells", "true"), True),
     }
 
 
@@ -813,6 +814,16 @@ class AssetManagerWindow(QMainWindow):
         self.simplify_check = QCheckBox("Simplify geometries")
         self.simplify_check.setChecked(bool(self.settings["import_simplify_geometries"]))
         opt_row.addWidget(self.simplify_check)
+
+        # Merge touching polygons that share identical attribute values into
+        # one feature. Helps both vector grid layers (one polygon per cell)
+        # and any dataset that's been needlessly split into adjacent slivers.
+        # Per-area attribute values are preserved; non-touching features
+        # stay separate.
+        self.dissolve_check = QCheckBox("Dissolve adjacent polygons (recommended)")
+        self.dissolve_check.setChecked(bool(self.settings["import_dissolve_grid_cells"]))
+        opt_row.addWidget(self.dissolve_check)
+
         opt_row.addStretch()
         layout.addLayout(opt_row)
 
@@ -916,6 +927,7 @@ class AssetManagerWindow(QMainWindow):
             cfg = _ensure_cfg()
             cfg["DEFAULT"]["import_validate_geometries"] = "true" if self.validate_check.isChecked() else "false"
             cfg["DEFAULT"]["import_simplify_geometries"] = "true" if self.simplify_check.isChecked() else "false"
+            cfg["DEFAULT"]["import_dissolve_grid_cells"]  = "true" if self.dissolve_check.isChecked()  else "false"
         except Exception:
             pass
 
@@ -988,6 +1000,58 @@ class AssetManagerWindow(QMainWindow):
             return geom.buffer(0)
         except Exception:
             return geom
+
+    def _dissolve_by_attributes(self, gdf: gpd.GeoDataFrame, label: str) -> gpd.GeoDataFrame:
+        """Merge polygons that share identical non-geometry attribute values
+        and are touching. Splits the dissolved multipart back into single-part
+        polygons so non-touching features stay separate. Preserves all
+        attribute values per area.
+
+        Designed for raster-derived layers where each pixel is its own
+        polygon; for irregular vector data with all-distinct attributes the
+        operation is a near no-op (and the log line will say so).
+        """
+        if gdf is None or gdf.empty or "geometry" not in gdf.columns:
+            return gdf
+        if not self.dissolve_check.isChecked():
+            return gdf
+        if len(gdf) < 2:
+            return gdf
+        attr_cols = [c for c in gdf.columns if c != gdf.geometry.name]
+        if not attr_cols:
+            return gdf
+
+        n_in = len(gdf)
+        try:
+            # Coerce attribute columns to a hashable string form so groupby
+            # works regardless of source dtype quirks (datetimes, decimals,
+            # mixed object columns from heterogeneous shapefiles).
+            work = gdf.copy()
+            for c in attr_cols:
+                try:
+                    work[c] = work[c].astype("string")
+                except Exception:
+                    work[c] = work[c].astype(str)
+            t0 = time.time()
+            dissolved = work.dissolve(by=attr_cols, as_index=False)
+            exploded = dissolved.explode(index_parts=False, ignore_index=True)
+            n_out = len(exploded)
+            dt = time.time() - t0
+            if n_out < n_in:
+                pct = 100.0 * (n_in - n_out) / n_in
+                self._log(
+                    f"{label}: dissolve merged {n_in:,} -> {n_out:,} polygons "
+                    f"({pct:.1f}% reduction, {dt:.1f}s)"
+                )
+            else:
+                self._log(
+                    f"{label}: dissolve found nothing to merge "
+                    f"({n_in:,} polygons unchanged, {dt:.1f}s)"
+                )
+            return exploded
+        except Exception as exc:
+            self._log(f"{label}: dissolve failed ({exc}) - keeping original", "WARN")
+            return gdf
 
     def _apply_quality_controls(self, gdf: gpd.GeoDataFrame, label: str) -> gpd.GeoDataFrame:
         if gdf is None or gdf.empty or "geometry" not in gdf.columns:
@@ -1067,6 +1131,7 @@ class AssetManagerWindow(QMainWindow):
                     if gdf.empty:
                         continue
                     gdf = self._apply_quality_controls(gdf, f"Assets:{fp.name}:{layer}")
+                    gdf = self._dissolve_by_attributes(gdf, f"Assets:{fp.name}:{layer}")
                     bbox_polygon = box(*gdf.total_bounds)
                     count = len(gdf)
                     asset_groups.append({
@@ -1102,6 +1167,7 @@ class AssetManagerWindow(QMainWindow):
                 if gdf.empty:
                     continue
                 gdf = self._apply_quality_controls(gdf, f"Assets:{fp.name}")
+                gdf = self._dissolve_by_attributes(gdf, f"Assets:{fp.name}")
                 layer = fp.stem
                 bbox_polygon = box(*gdf.total_bounds)
                 count = len(gdf)

--- a/code/asset_manage.py
+++ b/code/asset_manage.py
@@ -1007,10 +1007,14 @@ class AssetManagerWindow(QMainWindow):
         polygons so non-touching features stay separate. Preserves all
         attribute values per area.
 
-        Designed for raster-derived layers where each pixel is its own
-        polygon; for irregular vector data with all-distinct attributes the
-        operation is a near no-op (and the log line will say so).
+        Stages logged: "checking dissolve potential" -> "dissolving" -> result.
+        Per-layer (n_in, n_out, status) is appended to self._import_dissolve_stats
+        for the final import summary.
         """
+        # Ensure stats list exists even if caller didn't reset it.
+        if not hasattr(self, "_import_dissolve_stats"):
+            self._import_dissolve_stats: list[tuple[str, int, int, str]] = []
+
         if gdf is None or gdf.empty or "geometry" not in gdf.columns:
             return gdf
         if not self.dissolve_check.isChecked():
@@ -1022,6 +1026,12 @@ class AssetManagerWindow(QMainWindow):
             return gdf
 
         n_in = len(gdf)
+        col_word = "column" if len(attr_cols) == 1 else "columns"
+        self._log(
+            f"{label}: checking dissolve potential on {n_in:,} polygons "
+            f"(by {len(attr_cols)} attribute {col_word})..."
+        )
+
         try:
             # Coerce attribute columns to a hashable string form so groupby
             # works regardless of source dtype quirks (datetimes, decimals,
@@ -1032,25 +1042,64 @@ class AssetManagerWindow(QMainWindow):
                     work[c] = work[c].astype("string")
                 except Exception:
                     work[c] = work[c].astype(str)
+
+            # Pre-validate geometries: dissolve's underlying unary_union is
+            # sensitive to invalid rings (e.g. ChimpanzeeCombined.shp produced
+            # an IllegalArgumentException because LinearRings weren't closed).
+            # Always validate before dissolve regardless of the user's
+            # "Validate geometries" checkbox - this is dissolve's own
+            # defensive layer, not a user-visible quality control.
+            try:
+                work["geometry"] = work.geometry.apply(self._validate_geometry)
+                work = work[work.geometry.notna()]
+                work = work[~work.geometry.is_empty]
+            except Exception as v_exc:
+                self._log(f"{label}: geometry validation pass failed ({v_exc})", "WARN")
+            if work.empty:
+                self._log(
+                    f"{label}: all geometries invalid or empty after validation; "
+                    f"skipping dissolve, keeping original.", "WARN"
+                )
+                self._import_dissolve_stats.append((label, n_in, n_in, "invalid_input"))
+                return gdf
+
+            self._log(f"{label}: dissolving...")
             t0 = time.time()
             dissolved = work.dissolve(by=attr_cols, as_index=False)
             exploded = dissolved.explode(index_parts=False, ignore_index=True)
             n_out = len(exploded)
             dt = time.time() - t0
+
+            # Sanity check: dissolve should never reduce non-empty input to
+            # zero. If it does, something went wrong (likely a validity issue
+            # the buffer(0) / make_valid pass couldn't repair). Fall back to
+            # the original to avoid downstream code crashing on an empty GDF
+            # (e.g. box(*gdf.total_bounds) -> LinearRing error).
+            if n_out == 0:
+                self._log(
+                    f"{label}: dissolve produced 0 polygons from {n_in:,} input "
+                    f"({dt:.1f}s) - likely a geometry validity issue the "
+                    f"validator could not repair. Keeping original.", "WARN"
+                )
+                self._import_dissolve_stats.append((label, n_in, n_in, "produced_empty"))
+                return gdf
+
             if n_out < n_in:
                 pct = 100.0 * (n_in - n_out) / n_in
                 self._log(
-                    f"{label}: dissolve merged {n_in:,} -> {n_out:,} polygons "
-                    f"({pct:.1f}% reduction, {dt:.1f}s)"
+                    f"{label}: dissolved {n_in:,} -> {n_out:,} polygons "
+                    f"(-{n_in - n_out:,}, {pct:.1f}% reduction, {dt:.1f}s)"
                 )
             else:
                 self._log(
                     f"{label}: dissolve found nothing to merge "
                     f"({n_in:,} polygons unchanged, {dt:.1f}s)"
                 )
+            self._import_dissolve_stats.append((label, n_in, n_out, "ok"))
             return exploded
         except Exception as exc:
             self._log(f"{label}: dissolve failed ({exc}) - keeping original", "WARN")
+            self._import_dissolve_stats.append((label, n_in, n_in, "failed"))
             return gdf
 
     def _apply_quality_controls(self, gdf: gpd.GeoDataFrame, label: str) -> gpd.GeoDataFrame:
@@ -1209,15 +1258,46 @@ class AssetManagerWindow(QMainWindow):
     def _run_import_asset(self):
         self._update_progress(0)
         self._log("Step [Assets] STARTED")
+        # Reset per-run dissolve stats so the summary at the end is for this
+        # import only (not accumulated across multiple runs in the same window).
+        self._import_dissolve_stats = []
         try:
             asset_objects, asset_groups = self._import_spatial_data_asset()
             self._save_parquet("tbl_asset_object", asset_objects)
             self._save_parquet("tbl_asset_group", asset_groups)
+            self._log_import_summary(asset_objects, asset_groups)
             self._log("Step [Assets] COMPLETED")
         except Exception as exc:
             self._log(f"Step [Assets] FAILED: {exc}", "ERROR")
         finally:
             self._update_progress(100)
+
+    def _log_import_summary(self, asset_objects, asset_groups) -> None:
+        """Final, totalised report after all layers have been imported."""
+        n_groups = len(asset_groups) if asset_groups is not None else 0
+        n_final  = len(asset_objects) if asset_objects is not None else 0
+        sep = "-" * 60
+        self._log(sep)
+        self._log(f"Import summary: {n_groups} layer(s) imported -> {n_final:,} total polygons.")
+        stats = getattr(self, "_import_dissolve_stats", []) or []
+        if not stats:
+            self._log("  (Dissolve disabled or no eligible layers.)")
+            self._log(sep)
+            return
+        total_in  = sum(s[1] for s in stats)
+        total_out = sum(s[2] for s in stats)
+        n_reduced = total_in - total_out
+        pct = (100.0 * n_reduced / total_in) if total_in else 0.0
+        n_layers_changed = sum(1 for s in stats if s[2] < s[1] and s[3] == "ok")
+        n_layers_skipped = sum(1 for s in stats if s[3] != "ok")
+        self._log(f"  Polygons before dissolve: {total_in:>12,d}")
+        self._log(f"  Removed by dissolve:      {n_reduced:>12,d}  ({pct:.1f}% of input)")
+        self._log(f"  Polygons after dissolve:  {total_out:>12,d}")
+        msg = f"  Layers reduced: {n_layers_changed} of {len(stats)}"
+        if n_layers_skipped:
+            msg += f"  (skipped {n_layers_skipped} due to issues - see WARN lines above)"
+        self._log(msg)
+        self._log(sep)
 
     def _start_import(self):
         if self._import_running:

--- a/code/processing_internal.py
+++ b/code/processing_internal.py
@@ -487,6 +487,54 @@ def _panic_cfg(cfg: "configparser.ConfigParser | None" = None) -> tuple[int, int
     return pct, grace
 
 
+def _start_lifetime_panic_watchdog(panic_pct: int = 90, grace_s: int = 5):
+    """Process-wide sentinel that hard-exits the parent if RAM pressure stays
+    above panic_pct for grace_s seconds. Complements the per-pool watchdog
+    (_start_panic_watchdog) by also covering parent-side work between pools.
+    Returns the stop event, or None if psutil is unavailable.
+    See learning.md "Parent-side memory in the pipeline" for context.
+    """
+    import threading as _threading
+    if psutil is None:
+        return None
+    stop = _threading.Event()
+    state = {"since": None}
+
+    def _run():
+        while not stop.wait(1.0):
+            try:
+                pct = float(psutil.virtual_memory().percent)
+                now = time.time()
+                if pct >= panic_pct:
+                    if state["since"] is None:
+                        state["since"] = now
+                    elif (now - state["since"]) >= grace_s:
+                        try:
+                            rss_gb = psutil.Process().memory_info().rss / (1024 ** 3)
+                            sw_gb  = psutil.swap_memory().used / (1024 ** 3)
+                            log_to_gui(
+                                log_widget,
+                                f"[PANIC:lifetime] catastrophic RAM pressure "
+                                f"{pct:.0f}% >= {panic_pct}% for {grace_s}s "
+                                f"(parent RSS ~{rss_gb:.1f} GB, swap "
+                                f"~{sw_gb:.1f} GB). Hard-exiting process to "
+                                f"free the host. All pipeline progress for "
+                                f"this run is lost; rerun after the host "
+                                f"recovers."
+                            )
+                        except Exception:
+                            pass
+                        os._exit(137)
+                else:
+                    state["since"] = None
+            except Exception:
+                pass
+
+    t = _threading.Thread(target=_run, daemon=True, name="mesa-lifetime-panic")
+    t.start()
+    return stop
+
+
 # ----------------------------
 # Raster tiles integration helpers
 # ----------------------------
@@ -893,6 +941,12 @@ def read_parquet_or_empty(name: str) -> gpd.GeoDataFrame:
       3) <base>/input/geoparquet/<name>.parquet
       4) <base>/input/geoparquet/<name>/  (partitioned)
     Returns empty GeoDataFrame if none found.
+
+    WARNING: materialises the entire dataset (all parts, all geometries)
+    into a single in-process GeoDataFrame. Do not call from the parent
+    process for known-large tables (tbl_stacked, tbl_flat). Use a
+    directory glob for presence checks, pyarrow.dataset(...).count_rows()
+    for row counts, or read inside a worker process.
     """
     out_root = gpq_dir()
     in_root  = base_dir() / "input" / "geoparquet"
@@ -1970,11 +2024,45 @@ def process_tbl_stacked(cfg: configparser.ConfigParser,
     _ = intersect_assets_geocodes(assets, geocodes, cell_size_m, max_workers,
                                   asset_soft_limit, geocode_soft_limit)
 
+    # Release Stage 2 working sets before Stage 3 starts so flatten workers
+    # don't inherit the parent's intersect-time RSS.
     try:
-        sample = read_parquet_or_empty("tbl_stacked")
-        log_to_gui(log_widget, f"tbl_stacked rows (sample read): {len(sample):,}")
+        del assets, geocodes, groups
+    except Exception:
+        pass
+    try:
+        global _GRID_BBOX_MAP, _GRID_GDF, _GRID_OUT_DIR
+        _GRID_BBOX_MAP = {}
+        _GRID_GDF = None
+        _GRID_OUT_DIR = None
+    except Exception:
+        pass
+    for _ in range(2):
+        try:
+            gc.collect()
+        except Exception:
+            pass
+    if psutil is not None:
+        try:
+            rss_gb = psutil.Process().memory_info().rss / (1024 ** 3)
+            sw = psutil.swap_memory()
+            log_to_gui(
+                log_widget,
+                f"[stage2->stage3] post-intersect cleanup: parent RSS {rss_gb:.2f} GB, "
+                f"swap_used {sw.used/(1024**3):.1f} GB"
+            )
+        except Exception:
+            pass
+
+    # Presence check only - never materialise tbl_stacked here. See
+    # learning.md "Parent-side memory in the pipeline" and the docstring on
+    # read_parquet_or_empty.
+    try:
+        ds_dir = _dataset_dir("tbl_stacked")
+        n_parts = len(list(ds_dir.glob("*.parquet"))) if ds_dir.exists() else 0
+        log_to_gui(log_widget, f"tbl_stacked parts on disk: {n_parts}")
     except Exception as e:
-        log_to_gui(log_widget, f"tbl_stacked read check failed: {e}")
+        log_to_gui(log_widget, f"tbl_stacked presence check failed: {e}")
 
     update_progress(50)
 
@@ -2565,7 +2653,8 @@ def _backfill_worker(args):
     except Exception:
         return 0
 
-def flatten_tbl_stacked(config_file: Path, working_epsg: str):
+def flatten_tbl_stacked(config_file: Path, working_epsg: str,
+                        *, cleanup_slivers: bool = True):
     log_to_gui(log_widget, "Building presentation table (tbl_flat)…")
 
     # 1. Identify input files
@@ -2606,6 +2695,54 @@ def flatten_tbl_stacked(config_file: Path, working_epsg: str):
     except Exception:
         cfg_local = configparser.ConfigParser()
     index_weights = _load_index_weight_settings(cfg_local)
+
+    # 2b. Pre-flight memory check - refuse to start under existing pressure.
+    try:
+        preflight_max_pct = max(20, min(95, cfg_get_int(
+            cfg_local, "flatten_preflight_max_vm_percent", 60)))
+    except Exception:
+        preflight_max_pct = 60
+    try:
+        preflight_max_swap_gb = max(0.0, cfg_get_float(
+            cfg_local, "flatten_preflight_max_swap_gb", 5.0))
+    except Exception:
+        preflight_max_swap_gb = 5.0
+    if psutil is not None:
+        try:
+            vm = psutil.virtual_memory()
+            sw = psutil.swap_memory()
+            vm_pct = float(vm.percent)
+            swap_gb = float(sw.used) / (1024 ** 3)
+            log_to_gui(
+                log_widget,
+                f"[flatten] pre-flight: vm.percent={vm_pct:.1f}% (limit {preflight_max_pct}%), "
+                f"swap_used={swap_gb:.1f} GB (limit {preflight_max_swap_gb:.1f} GB)"
+            )
+            reasons = []
+            if vm_pct > preflight_max_pct:
+                reasons.append(
+                    f"vm.percent {vm_pct:.1f}% > {preflight_max_pct}%"
+                )
+            if swap_gb > preflight_max_swap_gb:
+                reasons.append(
+                    f"swap_used {swap_gb:.1f} GB > {preflight_max_swap_gb:.1f} GB "
+                    f"(swap residue from a previous stage)"
+                )
+            if reasons:
+                msg = (
+                    "[flatten] PRE-FLIGHT ABORT: " + "; ".join(reasons) + ". "
+                    "Host is too memory-constrained to start flatten safely. "
+                    "Wait for swap to drain (or restart the process), then "
+                    "rerun via run_flatten_only.py to skip the intersect "
+                    "rebuild."
+                )
+                log_to_gui(log_widget, msg)
+                raise RuntimeError(msg)
+        except RuntimeError:
+            raise
+        except Exception:
+            # Don't let psutil hiccups block flatten.
+            pass
 
     # 3. Run Parallel Map
     partials = []
@@ -2669,27 +2806,37 @@ def flatten_tbl_stacked(config_file: Path, working_epsg: str):
         mem_frac = 0.70
     mem_frac = min(0.95, max(0.30, mem_frac))
 
-    # Two-phase size split. Partition sizes are heavily skewed: the vast
-    # majority are tiny, but a small tail of large partitions drives worst-case
-    # memory. Separating them lets us run the small tail with broad
-    # parallelism (near-zero per-worker RAM) while still capping the heavy
-    # tail conservatively.
+    # Three-phase size split (partition sizes are heavily skewed):
+    #   huge  (>= flatten_huge_partition_mb)  -> SERIAL (1 worker)
+    #   large (>= flatten_large_partition_mb) -> workers_large in parallel
+    #   small (<  flatten_large_partition_mb) -> workers_small in parallel
     try:
         large_threshold_mb = float(cfg_local.get(
             "DEFAULT", "flatten_large_partition_mb", fallback="50"))
     except Exception:
         large_threshold_mb = 50.0
-    threshold_bytes = int(max(1.0, large_threshold_mb) * 1024 * 1024)
+    try:
+        huge_threshold_mb = float(cfg_local.get(
+            "DEFAULT", "flatten_huge_partition_mb", fallback="200"))
+    except Exception:
+        huge_threshold_mb = 200.0
+    if huge_threshold_mb < large_threshold_mb:
+        huge_threshold_mb = large_threshold_mb
+    large_bytes = int(max(1.0, large_threshold_mb) * 1024 * 1024)
+    huge_bytes  = int(max(1.0, huge_threshold_mb) * 1024 * 1024)
 
     try:
         sized = [(p, p.stat().st_size) for p in files]
     except Exception:
         sized = [(p, 0) for p in files]
 
-    large_sized = [t for t in sized if t[1] >= threshold_bytes]
-    small_sized = [t for t in sized if t[1] <  threshold_bytes]
+    huge_sized  = [t for t in sized if t[1] >= huge_bytes]
+    large_sized = [t for t in sized if huge_bytes > t[1] >= large_bytes]
+    small_sized = [t for t in sized if t[1] <  large_bytes]
+    huge_sized.sort(key=lambda t: t[1], reverse=True)
     large_sized.sort(key=lambda t: t[1], reverse=True)
     small_sized.sort(key=lambda t: t[1], reverse=True)
+    huge_files  = [p for p, _ in huge_sized]
     large_files = [p for p, _ in large_sized]
     small_files = [p for p, _ in small_sized]
 
@@ -2728,10 +2875,23 @@ def flatten_tbl_stacked(config_file: Path, working_epsg: str):
     workers_small = _resolve_phase_workers(
         flatten_small_override, small_gb_per_worker, len(small_files), "flatten-small")
 
-    log_to_gui(log_widget,
-               f"Flattening {len(files)} partitions in two phases: "
-               f"{len(large_files)} large (>={large_threshold_mb:.0f} MB) with {workers_large} workers, "
-               f"{len(small_files)} small with {workers_small} workers.")
+    if huge_files:
+        max_size_mb = max(t[1] for t in huge_sized) / (1024 * 1024)
+        log_to_gui(
+            log_widget,
+            f"Flattening {len(files)} partitions in three phases: "
+            f"{len(huge_files)} huge (>={huge_threshold_mb:.0f} MB, biggest {max_size_mb:.0f} MB) "
+            f"SERIAL, "
+            f"{len(large_files)} large (>={large_threshold_mb:.0f} MB) with {workers_large} workers, "
+            f"{len(small_files)} small with {workers_small} workers."
+        )
+    else:
+        log_to_gui(
+            log_widget,
+            f"Flattening {len(files)} partitions in two phases: "
+            f"{len(large_files)} large (>={large_threshold_mb:.0f} MB) with {workers_large} workers, "
+            f"{len(small_files)} small with {workers_small} workers."
+        )
 
     panic_pct, panic_grace_s = _panic_cfg(cfg_local)
 
@@ -2775,10 +2935,21 @@ def flatten_tbl_stacked(config_file: Path, working_epsg: str):
                 if res is not None:
                     partials.append(res)
 
-    # Pay the heavy phase first: big partitions run when the worker pool is
-    # freshest and nothing else is queued. Once they're done, swap to a wider
-    # pool for the small tail.
+    # Heaviest phase first, with progressively wider parallelism. gc.collect
+    # between phases gives the OS a chance to reclaim pages before the next
+    # round opens fresh worker memory.
+    if huge_files:
+        _run_flatten_pool(huge_files, 1, "flatten-huge")
+        try:
+            gc.collect()
+        except Exception:
+            pass
     _run_flatten_pool(large_files, workers_large, "flatten-large")
+    if large_files:
+        try:
+            gc.collect()
+        except Exception:
+            pass
     _run_flatten_pool(small_files, workers_small, "flatten-small")
 
     # Expose the large-phase value as max_workers for downstream sections
@@ -2994,6 +3165,31 @@ def flatten_tbl_stacked(config_file: Path, working_epsg: str):
         except Exception as e:
             log_to_gui(log_widget, f"[tbl_flat] MultiPolygon split failed; continuing without split: {e}")
 
+    # 6b. Sliver cleanup. Polygonised mosaics often produce a long tail of
+    # zero-area or sub-square-meter cells from edge precision; they pollute
+    # tbl_flat without representing any real area. Configurable threshold so
+    # advanced users can keep them (or raise the cutoff) via config + UI.
+    if cleanup_slivers and len(tbl_flat) > 0 and "area_m2" in tbl_flat.columns:
+        try:
+            sliver_min_m2 = float(cfg_local.get(
+                "DEFAULT", "flatten_sliver_min_area_m2", fallback="1.0"))
+        except Exception:
+            sliver_min_m2 = 1.0
+        try:
+            area_num = pd.to_numeric(tbl_flat["area_m2"], errors="coerce")
+            keep = area_num.fillna(0) >= sliver_min_m2
+            n_drop = int((~keep).sum())
+            if n_drop > 0:
+                before_n = len(tbl_flat)
+                tbl_flat = tbl_flat.loc[keep].reset_index(drop=True)
+                log_to_gui(log_widget,
+                           f"[tbl_flat] Sliver cleanup: dropped {n_drop:,} rows "
+                           f"with area_m2 < {sliver_min_m2:g} m^2 "
+                           f"({before_n:,} -> {len(tbl_flat):,}).")
+        except Exception as e:
+            log_to_gui(log_widget,
+                       f"[tbl_flat] Sliver cleanup skipped (error: {e}).")
+
     # 7. Select Columns & Write
     preferred = [
         'ref_geocodegroup','name_gis_geocodegroup','code',
@@ -3137,7 +3333,16 @@ def flatten_tbl_stacked(config_file: Path, working_epsg: str):
 # ----------------------------
 # Top-level process
 # ----------------------------
-def run_processing_pipeline(config_file: Path):
+def run_processing_pipeline(config_file: Path,
+                            *,
+                            run_prep: bool = True,
+                            run_intersect: bool = True,
+                            run_flatten: bool = True,
+                            cleanup_slivers: bool = True):
+    """Stages can be skipped independently. Soft validation: each stage that
+    depends on a previous output checks the artifact on disk and skips with a
+    clear log line instead of erroring out."""
+    lifetime_panic_stop = None
     try:
         cfg = read_config(config_file)
         set_global_cfg(cfg)  # <-- make parquet_folder available to gpq_dir()
@@ -3147,6 +3352,18 @@ def run_processing_pipeline(config_file: Path):
             HEARTBEAT_SECS = cfg_get_int(cfg, "heartbeat_secs", HEARTBEAT_SECS)
         except Exception:
             pass
+
+        # Process-wide RAM sentinel; backstop for parent-side work between
+        # pools. See learning.md "Parent-side memory in the pipeline".
+        try:
+            lp_pct = max(60, min(99, cfg_get_int(cfg, "mem_lifetime_panic_percent", 90)))
+        except Exception:
+            lp_pct = 90
+        try:
+            lp_grace = max(1, cfg_get_int(cfg, "mem_lifetime_panic_grace_secs", 5))
+        except Exception:
+            lp_grace = 5
+        lifetime_panic_stop = _start_lifetime_panic_watchdog(lp_pct, lp_grace)
 
         working_epsg = str(cfg["DEFAULT"].get("workingprojection_epsg","4326")).strip()
         raw_max_workers = str(cfg["DEFAULT"].get("max_workers", "")).strip()
@@ -3175,29 +3392,54 @@ def run_processing_pipeline(config_file: Path):
                       "approx_gb_per_worker": f"{approx_gb_per_worker:.2f}"},
                      force=True)
 
-        log_to_gui(log_widget, "[Stage 1/4] Preparing workspace and status files…")
-        cleanup_outputs(); update_progress(5)
-        _init_idle_status()
+        if run_prep:
+            log_to_gui(log_widget, "[Stage 1/4] Preparing workspace and status files…")
+            cleanup_outputs(); update_progress(5)
+            _init_idle_status()
+        else:
+            log_to_gui(log_widget, "[Stage 1/4] Skipped (Prep unchecked).")
 
-        log_to_gui(log_widget, "[Stage 2/4] Building stacked dataset (intersections & classification)…")
-        process_tbl_stacked(cfg, working_epsg, cell_size, max_workers,
-                            approx_gb_per_worker, mem_target_frac,
-                            asset_soft_limit, geocode_soft_limit)
+        if run_intersect:
+            log_to_gui(log_widget, "[Stage 2/4] Building stacked dataset (intersections & classification)…")
+            process_tbl_stacked(cfg, working_epsg, cell_size, max_workers,
+                                approx_gb_per_worker, mem_target_frac,
+                                asset_soft_limit, geocode_soft_limit)
+        else:
+            log_to_gui(log_widget, "[Stage 2/4] Skipped (Intersect unchecked).")
 
-        log_to_gui(log_widget, "[Stage 3/4] Flattening outputs, computing stats, and refreshing status…")
-        flatten_tbl_stacked(config_file, working_epsg); update_progress(95)
+        if run_flatten:
+            ds_dir = _dataset_dir("tbl_stacked")
+            n_parts = len(list(ds_dir.glob("*.parquet"))) if ds_dir.exists() else 0
+            if n_parts == 0:
+                log_to_gui(log_widget,
+                           "[Stage 3/4] Skipped: tbl_stacked has 0 parts on disk. "
+                           "Run Intersect first (or rerun with Intersect checked).")
+            else:
+                log_to_gui(log_widget, "[Stage 3/4] Flattening outputs, computing stats, and refreshing status…")
+                flatten_tbl_stacked(config_file, working_epsg,
+                                    cleanup_slivers=cleanup_slivers); update_progress(95)
+        else:
+            log_to_gui(log_widget, "[Stage 3/4] Skipped (Flatten unchecked).")
 
         # __mosaic_faces_tmp is produced by geocode_manage.py's polygonize
-        # step; the mosaic path does not clean it itself, so by the time the
-        # pipeline reaches this point it can be several hundred MB of dead
-        # weight. Fold it into the same Stage 3 cleanup sweep.
-        for temp_dir in ["__stacked_parts", "__grid_assign_in", "__grid_assign_out", "__mosaic_faces_tmp"]:
-            _rm_rf(_dataset_dir(temp_dir))
-        
+        # step; the mosaic path does not clean it itself. Only sweep when we
+        # actually ran a stage that may have produced these scratches.
+        if run_prep or run_intersect or run_flatten:
+            for temp_dir in ["__stacked_parts", "__grid_assign_in", "__grid_assign_out", "__mosaic_faces_tmp"]:
+                _rm_rf(_dataset_dir(temp_dir))
+
         log_to_gui(log_widget, "Core processing (stages 1-3) finished. Preparing raster tiles stage…")
     except Exception as e:
         log_to_gui(log_widget, f"Error during processing: {e}")
         raise
+    finally:
+        # Always stop the lifetime watchdog so a second pipeline run in the
+        # same process does not stack daemon threads.
+        if lifetime_panic_stop is not None:
+            try:
+                lifetime_panic_stop.set()
+            except Exception:
+                pass
 
 # ----------------------------
 # Minimap (Leaflet in pywebview) — helper process
@@ -3888,6 +4130,11 @@ def intersect_assets_geocodes(asset_data: gpd.GeoDataFrame,
     if error_msg: raise RuntimeError(error_msg)
     if not files:
         log_to_gui(log_widget, "No intersections; tbl_stacked is empty.")
+        # Release before returning so caller's frame doesn't keep these alive.
+        try: del chunks, tagged
+        except Exception: pass
+        try: gc.collect()
+        except Exception: pass
         return gpd.GeoDataFrame(geometry=[], crs=geocode_data.crs)
     final_ds = _dataset_dir("tbl_stacked"); _rm_rf(final_ds)
     try: Path(tmp_parts).rename(final_ds)
@@ -3896,6 +4143,12 @@ def intersect_assets_geocodes(asset_data: gpd.GeoDataFrame,
         for f in Path(tmp_parts).glob("*.parquet"): shutil.move(str(f), str(final_ds / f.name))
         _rm_rf(tmp_parts)
     log_to_gui(log_widget, f"tbl_stacked dataset written as folder with {len(files)} parts and ~{written:,} rows: {final_ds}")
+    # Release intersect working sets before returning so the caller can
+    # transition to flatten without inheriting them.
+    try: del chunks, tagged, chunk_cells
+    except Exception: pass
+    try: gc.collect()
+    except Exception: pass
     return gpd.GeoDataFrame(geometry=[], crs=geocode_data.crs)
 
 
@@ -3905,11 +4158,20 @@ def intersect_assets_geocodes(asset_data: gpd.GeoDataFrame,
 _EXPLODE_TBL_FLAT_MULTIPOLYGONS: bool = False
 
 
-def run_headless(original_working_directory_arg: str | None = None, *, explode_flat_multipolygons: bool = False, log_fn=None) -> None:
+def run_headless(original_working_directory_arg: str | None = None,
+                 *,
+                 explode_flat_multipolygons: bool = False,
+                 log_fn=None,
+                 run_prep: bool = True,
+                 run_intersect: bool = True,
+                 run_flatten: bool = True,
+                 cleanup_slivers: bool = True) -> None:
     """Entry point for headless processing (callable from other modules).
 
     This mirrors the __main__ headless initialization without calling sys.exit.
     If *log_fn* is provided, log output is routed there instead of stdout.
+    The run_prep/run_intersect/run_flatten flags are forwarded to
+    run_processing_pipeline so callers can rerun individual data stages.
     """
     global _external_log_fn
     _external_log_fn = log_fn
@@ -3959,7 +4221,11 @@ def run_headless(original_working_directory_arg: str | None = None, *, explode_f
     _EXPLODE_TBL_FLAT_MULTIPOLYGONS = bool(explode_flat_multipolygons)
 
     try:
-        run_processing_pipeline(cfg_path)
+        run_processing_pipeline(cfg_path,
+                                run_prep=run_prep,
+                                run_intersect=run_intersect,
+                                run_flatten=run_flatten,
+                                cleanup_slivers=cleanup_slivers)
     finally:
         _external_log_fn = None
 

--- a/code/processing_internal.py
+++ b/code/processing_internal.py
@@ -415,6 +415,79 @@ def _log_memory_snapshot(context: str, extra: dict | None = None, force: bool = 
         pass
 
 # ----------------------------
+# Memory panic watchdog helper
+# ----------------------------
+def _start_panic_watchdog(label: str, panic_pct: int, grace_s: int):
+    """
+    Start a daemon thread that monitors psutil.virtual_memory().percent and
+    terminates the registered multiprocessing pool if pressure crosses
+    panic_pct for grace_s consecutive seconds. Returns (state, stop_event,
+    thread). Caller must:
+      - assign state["pool"] = pool right after the pool is opened
+      - check state["triggered"] inside the imap_unordered loop and break
+      - call stop_event.set() when the pool block exits
+    The watchdog is a no-op if psutil is unavailable.
+    """
+    import threading as _threading
+    state = {"triggered": False, "pool": None, "since": None,
+             "panic_pct": int(panic_pct), "grace_s": int(grace_s),
+             "label": str(label)}
+    stop = _threading.Event()
+
+    def _run():
+        if psutil is None:
+            return
+        while not stop.wait(2.0):
+            try:
+                pct = psutil.virtual_memory().percent
+                now = time.time()
+                if pct >= state["panic_pct"]:
+                    if state["since"] is None:
+                        state["since"] = now
+                    elif (now - state["since"]) >= state["grace_s"] and not state["triggered"]:
+                        state["triggered"] = True
+                        try:
+                            rss_gb = psutil.Process().memory_info().rss / (1024 ** 3)
+                        except Exception:
+                            rss_gb = float("nan")
+                        log_to_gui(
+                            log_widget,
+                            f"[PANIC:{state['label']}] RAM pressure {pct:.0f}% "
+                            f">= {state['panic_pct']}% for {state['grace_s']}s "
+                            f"(parent RSS ~{rss_gb:.1f} GB). Terminating pool to "
+                            f"avoid swap death. Lower max_workers or per-stage caps "
+                            f"and retry."
+                        )
+                        pool = state.get("pool")
+                        if pool is not None:
+                            try:
+                                pool.terminate()
+                            except Exception:
+                                pass
+                        return
+                else:
+                    state["since"] = None
+            except Exception:
+                pass
+
+    t = _threading.Thread(target=_run, daemon=True)
+    t.start()
+    return state, stop, t
+
+
+def _panic_cfg(cfg: "configparser.ConfigParser | None" = None) -> tuple[int, int]:
+    """Read mem_panic_percent / mem_panic_grace_secs from cfg with safe defaults."""
+    pct, grace = 75, 10
+    try:
+        cfg_ref = cfg if cfg is not None else _ensure_cfg()
+        pct = max(50, min(99, cfg_get_int(cfg_ref, "mem_panic_percent", 75)))
+        grace = max(1, cfg_get_int(cfg_ref, "mem_panic_grace_secs", 10))
+    except Exception:
+        pass
+    return pct, grace
+
+
+# ----------------------------
 # Raster tiles integration helpers
 # ----------------------------
 def _tbl_flat_path() -> Path:
@@ -1603,10 +1676,19 @@ def _intersection_worker(args):
 # Memory heuristics
 # ----------------------------
 def _estimate_worker_memory_gb(asset_df: gpd.GeoDataFrame,
-                               geocode_df: gpd.GeoDataFrame) -> tuple[float | None, float | None]:
+                               geocode_df: gpd.GeoDataFrame,
+                               cfg: "configparser.ConfigParser | None" = None,
+                               ) -> tuple[float | None, float | None]:
     """
     Approximate memory footprint for one worker when dataframes are pickled
     to child processes (Windows spawn). Returns (~GB per worker, ~GB of data).
+
+    The default 1.5x overhead multiplier is conservative for the worst case
+    (full pickled copy + sindex + groupby buffers). On hosts where workers
+    actually hold only chunk slices, observed RSS is closer to 0.7-0.9x of
+    data size, so the estimate caps worker count too aggressively. The
+    config knob `stage2_worker_overhead_multiplier` lets the operator tune
+    this per dataset/host without changing code.
     """
     def _estimate_gdf(gdf: gpd.GeoDataFrame) -> float:
         if gdf is None or len(gdf) == 0:
@@ -1645,8 +1727,18 @@ def _estimate_worker_memory_gb(asset_df: gpd.GeoDataFrame,
     if total_gb <= 0:
         return None, None
 
-    # Each worker holds full assets+geocodes; add overhead for spatial index/geometry copies
-    per_worker_gb = max(0.75, total_gb * 1.5)
+    # Each worker holds full assets+geocodes; add overhead for spatial index/geometry copies.
+    # Floor the multiplier at 1.0 even if the operator has lowered it: anything below
+    # that ignores join-result expansion (an sjoin can multiply rows several-fold) and
+    # has caused 100+ GB peak-RSS events on large Apple Silicon datasets where
+    # psutil's "available" reading misled the budgeting math.
+    multiplier = 1.5
+    if cfg is not None:
+        try:
+            multiplier = max(1.0, cfg_get_float(cfg, "stage2_worker_overhead_multiplier", 1.5))
+        except Exception:
+            multiplier = 1.5
+    per_worker_gb = max(0.75, total_gb * multiplier)
     return per_worker_gb, total_gb
 
 # ----------------------------
@@ -1779,7 +1871,7 @@ def process_tbl_stacked(cfg: configparser.ConfigParser,
         if keep:
             assets = assets.merge(groups[keep], left_on='ref_asset_group', right_on='id', how='left')
 
-    est_worker_gb, est_data_gb = _estimate_worker_memory_gb(assets, geocodes)
+    est_worker_gb, est_data_gb = _estimate_worker_memory_gb(assets, geocodes, cfg)
     effective_worker_gb = max(0.5, approx_gb_per_worker)
     if est_worker_gb:
         effective_worker_gb = max(effective_worker_gb, est_worker_gb)
@@ -1819,15 +1911,49 @@ def process_tbl_stacked(cfg: configparser.ConfigParser,
         if psutil is not None:
             vm = psutil.virtual_memory()
             avail_gb = vm.available / (1024**3)
+            total_gb = vm.total / (1024**3)
+            try:
+                parent_rss_gb = float(psutil.Process().memory_info().rss) / (1024**3)
+            except Exception:
+                parent_rss_gb = 0.0
             headroom_gb = max(0.5, cfg_get_float(cfg, "mem_headroom_gb", 1.5))
+
+            # Available-based budget: how much we can grow into right now.
             avail_after_headroom = max(0.5, avail_gb - headroom_gb)
-            budget_gb = max(0.5, avail_after_headroom * mem_target_frac)
-            allowed = max(1, int(budget_gb // max(0.5, effective_worker_gb)))
+            avail_budget_gb = max(0.5, avail_after_headroom * mem_target_frac)
+            allowed_avail = max(1, int(avail_budget_gb // max(0.5, effective_worker_gb)))
+
+            # Total-RAM-based ceiling: protects against macOS unified memory
+            # over-reporting "available" (which on M-series can stay high right
+            # up until the host falls into swap-death). Treats the whole RAM
+            # bank minus parent-process RSS as the real ceiling, then applies
+            # mem_target_frac on top so we never plan to consume the whole box.
+            total_after_parent = max(0.5, total_gb - parent_rss_gb)
+            total_budget_gb = max(0.5, total_after_parent * mem_target_frac)
+            allowed_total = max(1, int(total_budget_gb // max(0.5, effective_worker_gb)))
+
+            allowed = min(allowed_avail, allowed_total)
+
             log_to_gui(
                 log_widget,
-                f"[workers] RAM avail ~{avail_gb:.1f} GB -> budget ~{budget_gb:.1f} GB (headroom {headroom_gb:.1f} GB, {effective_worker_gb:.1f} GB/worker) => {allowed} workers",
+                f"[workers] RAM total {total_gb:.1f} GB, avail {avail_gb:.1f} GB, "
+                f"parent ~{parent_rss_gb:.1f} GB; "
+                f"avail-budget {avail_budget_gb:.1f} GB ({allowed_avail} workers), "
+                f"total-budget {total_budget_gb:.1f} GB ({allowed_total} workers); "
+                f"per-worker ~{effective_worker_gb:.1f} GB -> using {allowed} workers."
             )
             max_workers = min(max_workers, allowed)
+
+            # Predicted peak preview so the operator sees the worst case
+            # (parent + N workers x per-worker) before the pool spawns.
+            est_peak = parent_rss_gb + max_workers * effective_worker_gb
+            peak_pct = 100.0 * est_peak / max(1.0, total_gb)
+            warn = " — WARNING: predicted peak exceeds 90% of RAM" if peak_pct >= 90 else ""
+            log_to_gui(
+                log_widget,
+                f"[workers] predicted peak RSS ~{est_peak:.1f} GB "
+                f"(~{peak_pct:.0f}% of {total_gb:.1f} GB){warn}"
+            )
     except Exception:
         pass
 
@@ -2607,6 +2733,8 @@ def flatten_tbl_stacked(config_file: Path, working_epsg: str):
                f"{len(large_files)} large (>={large_threshold_mb:.0f} MB) with {workers_large} workers, "
                f"{len(small_files)} small with {workers_small} workers.")
 
+    panic_pct, panic_grace_s = _panic_cfg(cfg_local)
+
     def _run_flatten_pool(paths, n_workers: int, label: str) -> None:
         if not paths:
             return
@@ -2614,11 +2742,33 @@ def flatten_tbl_stacked(config_file: Path, working_epsg: str):
         if _mp_allowed() and n_workers > 1:
             # imap_unordered so each worker's payload is consumed and released
             # as it returns, rather than buffering all partials to the end.
-            with multiprocessing.get_context("spawn").Pool(n_workers) as pool:
-                args = [(f, ranges_map, desc_map, index_weights) for f in paths]
-                for res in pool.imap_unordered(_flatten_worker, args, chunksize=1):
-                    if res is not None:
-                        partials.append(res)
+            pstate, pstop, pthread = _start_panic_watchdog(label, panic_pct, panic_grace_s)
+            try:
+                with multiprocessing.get_context("spawn").Pool(n_workers) as pool:
+                    pstate["pool"] = pool
+                    args = [(f, ranges_map, desc_map, index_weights) for f in paths]
+                    try:
+                        for res in pool.imap_unordered(_flatten_worker, args, chunksize=1):
+                            if pstate["triggered"]:
+                                raise RuntimeError(
+                                    f"{label} aborted by memory panic watchdog "
+                                    f"(>{panic_pct}% RAM for >={panic_grace_s}s)"
+                                )
+                            if res is not None:
+                                partials.append(res)
+                    except Exception:
+                        if pstate["triggered"]:
+                            raise RuntimeError(
+                                f"{label} aborted by memory panic watchdog "
+                                f"(>{panic_pct}% RAM for >={panic_grace_s}s)"
+                            )
+                        raise
+                    finally:
+                        pstate["pool"] = None
+            finally:
+                pstop.set()
+                try: pthread.join(timeout=1.5)
+                except Exception: pass
         else:
             for f in paths:
                 res = _flatten_worker((f, ranges_map, desc_map, index_weights))
@@ -2928,10 +3078,26 @@ def flatten_tbl_stacked(config_file: Path, working_epsg: str):
             log_to_gui(log_widget,
                        f"Backfill: {len(files)} partitions using {backfill_workers} workers…")
             if _mp_allowed() and backfill_workers > 1:
-                with multiprocessing.get_context("spawn").Pool(backfill_workers) as pool:
-                    args = [(f, worker_area_arg) for f in files]
-                    for count in pool.imap_unordered(_backfill_worker, args):
-                        touched += count
+                bf_pct, bf_grace = _panic_cfg(cfg_local)
+                pstate, pstop, pthread = _start_panic_watchdog("backfill", bf_pct, bf_grace)
+                try:
+                    with multiprocessing.get_context("spawn").Pool(backfill_workers) as pool:
+                        pstate["pool"] = pool
+                        args = [(f, worker_area_arg) for f in files]
+                        try:
+                            for count in pool.imap_unordered(_backfill_worker, args):
+                                if pstate["triggered"]:
+                                    raise RuntimeError(
+                                        f"backfill aborted by memory panic watchdog "
+                                        f"(>{bf_pct}% RAM for >={bf_grace}s)"
+                                    )
+                                touched += count
+                        finally:
+                            pstate["pool"] = None
+                finally:
+                    pstop.set()
+                    try: pthread.join(timeout=1.5)
+                    except Exception: pass
             else:
                 for f in files:
                     touched += _backfill_worker((f, worker_area_arg))
@@ -3582,6 +3748,16 @@ def intersect_assets_geocodes(asset_data: gpd.GeoDataFrame,
     except Exception: geom_types = ["Polygon","MultiPolygon","LineString","Point"]
     progress_state = {"done": 0, "rows": 0, "started_at": time.time()}
     hb_stop = threading.Event()
+
+    # Memory panic watchdog. Stage 2 can move from comfortable to swapping
+    # within seconds when an sjoin against a dense asset region produces 10x
+    # the row count the estimator predicted. The watchdog terminates the
+    # pool cleanly when host RAM pressure crosses mem_panic_percent.
+    panic_pct, panic_grace_s = _panic_cfg()
+    panic_state, panic_stop, wd_thread = _start_panic_watchdog(
+        "intersect", panic_pct, panic_grace_s
+    )
+
     def _heartbeat():
         while not hb_stop.wait(HEARTBEAT_SECS):
             try:
@@ -3651,21 +3827,39 @@ def intersect_assets_geocodes(asset_data: gpd.GeoDataFrame,
     if _mp_allowed() and max_workers > 1:
         ctx = multiprocessing.get_context("spawn")
         with ctx.Pool(processes=max_workers, initializer=_intersect_pool_init, initargs=(asset_data, geom_types, str(tmp_parts), asset_soft_limit, geocode_soft_limit)) as pool:
-            for (idx, nrows, paths, err, logs) in pool.imap_unordered(_intersection_worker, iterable):
-                progress_state["done"] += 1; done_count = progress_state["done"]
-                if logs:
-                    for line in logs: log_to_gui(log_widget, line)
-                if err:
-                    error_msg = err; log_to_gui(log_widget, f"[intersect] Chunk {idx} failed: {err}")
-                    try: pool.terminate()
-                    except Exception: pass
-                    break
-                written += int(nrows or 0); progress_state["rows"] = written
-                if paths:
-                    if isinstance(paths, list): files.extend(paths)
-                    else: files.append(paths)
-                _update_status(done_count); _tick_progress(done_count, written, progress_state["started_at"])
-                if done_count % 8 == 0: gc.collect()
+            panic_state["pool"] = pool
+            try:
+                for (idx, nrows, paths, err, logs) in pool.imap_unordered(_intersection_worker, iterable):
+                    if panic_state["triggered"]:
+                        error_msg = (
+                            f"intersection aborted by memory panic watchdog "
+                            f"(>{panic_pct}% RAM for >={panic_grace_s}s)"
+                        )
+                        break
+                    progress_state["done"] += 1; done_count = progress_state["done"]
+                    if logs:
+                        for line in logs: log_to_gui(log_widget, line)
+                    if err:
+                        error_msg = err; log_to_gui(log_widget, f"[intersect] Chunk {idx} failed: {err}")
+                        try: pool.terminate()
+                        except Exception: pass
+                        break
+                    written += int(nrows or 0); progress_state["rows"] = written
+                    if paths:
+                        if isinstance(paths, list): files.extend(paths)
+                        else: files.append(paths)
+                    _update_status(done_count); _tick_progress(done_count, written, progress_state["started_at"])
+                    if done_count % 8 == 0: gc.collect()
+            except Exception as e:
+                if panic_state["triggered"]:
+                    error_msg = (
+                        f"intersection aborted by memory panic watchdog "
+                        f"(>{panic_pct}% RAM for >={panic_grace_s}s)"
+                    )
+                else:
+                    raise
+            finally:
+                panic_state["pool"] = None
     else:
         _intersect_pool_init(asset_data, geom_types, str(tmp_parts), asset_soft_limit, geocode_soft_limit)
         for args in iterable:
@@ -3683,6 +3877,9 @@ def intersect_assets_geocodes(asset_data: gpd.GeoDataFrame,
             if done_count % 8 == 0: gc.collect()
     try:
         hb_stop.set(); hb_thread.join(timeout=1.5)
+        try:
+            panic_stop.set(); wd_thread.join(timeout=1.5)
+        except Exception: pass
     except Exception: pass
     try:
         for c in cells_meta: c["state"] = "done"

--- a/code/processing_pipeline_run.py
+++ b/code/processing_pipeline_run.py
@@ -30,7 +30,7 @@ from mesa_shared import find_base_dir as resolve_base_dir, read_config, parquet_
 from PySide6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, QGridLayout,
     QGroupBox, QLabel, QPushButton, QPlainTextEdit, QCheckBox, QProgressBar,
-    QFrame, QSizePolicy,
+    QFrame, QSizePolicy, QRadioButton, QButtonGroup,
 )
 from PySide6.QtGui import QIcon, QFont
 from PySide6.QtCore import Qt, QTimer, Signal, QObject
@@ -90,11 +90,21 @@ class ProcessAvailability:
 
 @dataclass(frozen=True)
 class ProcessPlan:
-    run_data: bool
+    # Data-processing sub-stages. Any True triggers run_data_process; the
+    # internal pipeline honours each flag independently with soft validation.
+    run_prep: bool
+    run_intersect: bool
+    run_flatten: bool
     explode_flat_multipolygons: bool
+    cleanup_slivers: bool
     run_tiles: bool
     run_lines: bool
     run_analysis: bool
+
+    @property
+    def run_data(self) -> bool:
+        """True if any of the three data sub-stages is selected."""
+        return bool(self.run_prep or self.run_intersect or self.run_flatten)
 
 
 def _exists_any(paths: Iterable[Path]) -> bool:
@@ -389,8 +399,16 @@ def run_data_process(
     progress_fn: Callable[[float], None],
     *,
     explode_flat_multipolygons: bool = False,
+    run_prep: bool = True,
+    run_intersect: bool = True,
+    run_flatten: bool = True,
+    cleanup_slivers: bool = True,
 ) -> None:
     """Run the data-processing pipeline.
+
+    Sub-stages (prep / intersect / flatten) can be skipped independently
+    via the run_* flags; the internal pipeline does soft validation and
+    logs a clear skip line when an upstream artifact is missing.
 
     Important: when frozen (PyInstaller), calling a .py via `sys.executable` does not work.
     We therefore run the pipeline in-process by importing the internal module.
@@ -414,7 +432,15 @@ def run_data_process(
             step=1.2,
             interval_s=0.8,
         )
-        dpi.run_headless(str(base_dir), explode_flat_multipolygons=bool(explode_flat_multipolygons), log_fn=log_fn)
+        dpi.run_headless(
+            str(base_dir),
+            explode_flat_multipolygons=bool(explode_flat_multipolygons),
+            log_fn=log_fn,
+            run_prep=bool(run_prep),
+            run_intersect=bool(run_intersect),
+            run_flatten=bool(run_flatten),
+            cleanup_slivers=bool(cleanup_slivers),
+        )
         stop_pulse.set()
         try:
             pulse_thread.join(timeout=0.2)
@@ -1420,12 +1446,23 @@ def run_selected(
     if plan.run_data:
         try:
             s, e = ranges.get("data", (0.0, 100.0))
-            _log_line(base_dir, log_fn, f"[Process] Progress range data: {s:.1f}% -> {e:.1f}%")
+            sub_summary = ", ".join([
+                name for name, on in [("prep", plan.run_prep),
+                                       ("intersect", plan.run_intersect),
+                                       ("flatten", plan.run_flatten)]
+                if on
+            ]) or "(none)"
+            _log_line(base_dir, log_fn,
+                      f"[Process] Progress range data: {s:.1f}% -> {e:.1f}% (sub-stages: {sub_summary})")
             run_data_process(
                 base_dir,
                 log_fn,
                 make_slice_progress(s, e),
                 explode_flat_multipolygons=bool(plan.explode_flat_multipolygons),
+                run_prep=bool(plan.run_prep),
+                run_intersect=bool(plan.run_intersect),
+                run_flatten=bool(plan.run_flatten),
+                cleanup_slivers=bool(plan.cleanup_slivers),
             )
         except Exception as exc:
             _log_line(base_dir, log_fn, f"ERROR: data processing failed: {exc}")
@@ -1437,8 +1474,14 @@ def run_selected(
             _log_line(base_dir, log_fn, f"[Process] Progress range tiles: {s:.1f}% -> {e:.1f}%")
             gpq = parquet_dir(base_dir, cfg)
             if not _exists_any([gpq / "tbl_flat.parquet"]):
-                raise FileNotFoundError("tbl_flat.parquet is missing; run data processing first")
-            run_tiles_process(base_dir, cfg, log_fn, make_slice_progress(s, e))
+                # Soft skip: user opted in to tiles but the upstream artifact
+                # is not on disk. Honour the rerun-parts intent rather than
+                # failing the whole batch.
+                _log_line(base_dir, log_fn,
+                          "Tiles: skipped - tbl_flat.parquet is missing. "
+                          "Run Flatten (or Data processing end-to-end) first.")
+            else:
+                run_tiles_process(base_dir, cfg, log_fn, make_slice_progress(s, e))
         except Exception as exc:
             _log_line(base_dir, log_fn, f"ERROR: raster tiles failed: {exc}")
             had_errors = True
@@ -1548,14 +1591,6 @@ class ProcessRunnerWindow(QMainWindow):
         prog_row.addWidget(self._progress_bar, stretch=1)
         layout.addLayout(prog_row)
 
-        # Info label
-        info_label = QLabel(
-            "Run one or more processing steps in one batch. "
-            "Unavailable steps are disabled when required input tables are missing."
-        )
-        info_label.setWordWrap(True)
-        layout.addWidget(info_label)
-
         # Availability
         avail_data = detect_data_processing(base_dir, cfg)
         avail_tiles = detect_tiles_processing(base_dir, cfg)
@@ -1566,8 +1601,37 @@ class ProcessRunnerWindow(QMainWindow):
         tiles_flat_exists = _exists_any([gpq / "tbl_flat.parquet"])
         tiles_default = bool(avail_tiles.available and (tiles_flat_exists or avail_data.available))
 
-        # Checkbox grid
+        # Stash availability for the Normal-mode worker, which builds a plan
+        # straight from these instead of reading checkbox state.
+        self._avail_data = avail_data
+        self._avail_tiles = avail_tiles
+        self._avail_lines = avail_lines
+        self._avail_analysis = avail_analysis
+        self._tiles_flat_exists = tiles_flat_exists
+
+        # Mode selector: Normal hides the checkbox grid and runs everything
+        # available in one click. Advanced shows the per-stage checkboxes.
+        mode_row = QHBoxLayout()
+        mode_row.addWidget(QLabel("Mode:"))
+        self._rb_normal   = QRadioButton("Normal")
+        self._rb_advanced = QRadioButton("Advanced")
+        self._rb_normal.setChecked(True)
+        self._mode_group = QButtonGroup(self)
+        self._mode_group.addButton(self._rb_normal)
+        self._mode_group.addButton(self._rb_advanced)
+        mode_row.addWidget(self._rb_normal)
+        mode_row.addWidget(self._rb_advanced)
+        mode_row.addStretch()
+        layout.addLayout(mode_row)
+
+        # Info label adapts to the active mode.
+        self._info_label = QLabel()
+        self._info_label.setWordWrap(True)
+        layout.addWidget(self._info_label)
+
+        # Checkbox grid (only visible in Advanced mode).
         grid_widget = QWidget()
+        self._advanced_panel = grid_widget
         grid = QGridLayout(grid_widget)
         grid.setContentsMargins(10, 0, 10, 0)
 
@@ -1591,43 +1655,114 @@ class ProcessRunnerWindow(QMainWindow):
                 cb.setChecked(False)
             return cb
 
-        self._cb_data = _mk_row(1, "Data processing (presentation)", avail_data.available, avail_data)
-        tiles_status = "Run data processing first" if not tiles_flat_exists else None
-        self._cb_tiles = _mk_row(2, "Tiles processing (MBTiles)", tiles_default, avail_tiles, tiles_status)
-        self._cb_lines = _mk_row(3, "Lines processing (segments)", avail_lines.available, avail_lines)
-        self._cb_analysis = _mk_row(4, "Analysis processing (study areas)", avail_analysis.available, avail_analysis)
+        # Row 1: master "Process" checkbox (cascades to data sub-stages + tiles).
+        self._cb_data_master = QCheckBox("Process (data: prep + intersect + flatten + tiles)")
+        self._cb_data_master.setTristate(True)
+        self._cb_data_master.setEnabled(avail_data.available)
+        self._cb_data_master.setChecked(avail_data.available)
+        grid.addWidget(self._cb_data_master, 1, 0)
+        master_status = "Ready" if avail_data.available else (
+            "; ".join(avail_data.reasons) if avail_data.reasons else "Missing inputs")
+        grid.addWidget(QLabel(master_status), 1, 1)
 
-        # Explode option in column 2, row 1
+        # Flatten options stack vertically in column 2 of the master row.
+        opts_col = QVBoxLayout()
+        opts_col.setContentsMargins(0, 0, 0, 0)
+        opts_col.setSpacing(2)
         self._cb_data_explode = QCheckBox("Split MultiPolygons in tbl_flat")
         self._cb_data_explode.setChecked(False)
-        grid.addWidget(self._cb_data_explode, 1, 2)
+        opts_col.addWidget(self._cb_data_explode)
+        # Sliver cleanup defaults on; uncheck to keep zero-area / <1 m^2 rows.
+        self._cb_cleanup_slivers = QCheckBox("Drop sliver cells (<1 m²)")
+        self._cb_cleanup_slivers.setChecked(True)
+        opts_col.addWidget(self._cb_cleanup_slivers)
+        opts_host = QWidget()
+        opts_host.setLayout(opts_col)
+        grid.addWidget(opts_host, 1, 2)
+
+        # Sub-rows 1a / 1b / 1c: three data sub-stages, indented.
+        def _mk_sub(row, text, default_checked):
+            cb = QCheckBox("    " + text)  # indent for visual hierarchy
+            cb.setEnabled(avail_data.available)
+            cb.setChecked(default_checked and avail_data.available)
+            grid.addWidget(cb, row, 0)
+            return cb
+
+        self._cb_prep      = _mk_sub(2, "Prep (workspace, status)", avail_data.available)
+        self._cb_intersect = _mk_sub(3, "Intersect (build tbl_stacked)", avail_data.available)
+        self._cb_flatten   = _mk_sub(4, "Flatten (build tbl_flat)", avail_data.available)
+
+        # Existing rows shifted down. Tiles cascades from master too.
+        tiles_status = "Run Flatten (or full data) first" if not tiles_flat_exists else None
+        self._cb_tiles = _mk_row(5, "Tiles processing (MBTiles)", tiles_default, avail_tiles, tiles_status)
+        self._cb_lines = _mk_row(6, "Lines processing (segments)", avail_lines.available, avail_lines)
+        self._cb_analysis = _mk_row(7, "Analysis processing (study areas)", avail_analysis.available, avail_analysis)
 
         layout.addWidget(grid_widget)
 
-        # Sync logic for data option / tiles state
+        # ----- Master <-> sub cascade -----
+        # Use `clicked` (fires only on user interaction, not setCheckState) so
+        # programmatic updates don't recurse - no guard flag needed.
+        sub_cbs = [self._cb_prep, self._cb_intersect, self._cb_flatten, self._cb_tiles]
+
+        def _on_master_clicked():
+            state = self._cb_data_master.checkState()
+            # Tristate cycles user clicks through Unchecked → PartiallyChecked → Checked;
+            # treat Partial as "user wants all on".
+            if state == Qt.PartiallyChecked:
+                state = Qt.Checked
+                self._cb_data_master.setCheckState(Qt.Checked)
+            new_checked = (state == Qt.Checked)
+            for cb in sub_cbs:
+                if cb.isEnabled():
+                    cb.setChecked(new_checked)
+            _sync_data_option()
+            _sync_tiles()
+
+        def _refresh_master_state():
+            enabled_subs = [cb for cb in sub_cbs if cb.isEnabled()]
+            if not enabled_subs:
+                self._cb_data_master.setCheckState(Qt.Unchecked)
+                return
+            states = [cb.isChecked() for cb in enabled_subs]
+            if all(states):
+                self._cb_data_master.setCheckState(Qt.Checked)
+            elif any(states):
+                self._cb_data_master.setCheckState(Qt.PartiallyChecked)
+            else:
+                self._cb_data_master.setCheckState(Qt.Unchecked)
+
         def _sync_data_option():
-            enabled = self._cb_data.isChecked() and avail_data.available
+            # Explode option requires Flatten; it's the stage that writes tbl_flat.
+            enabled = self._cb_flatten.isChecked() and avail_data.available
             self._cb_data_explode.setEnabled(enabled)
             if not enabled:
                 self._cb_data_explode.setChecked(False)
 
         def _sync_tiles():
             helper_ok = avail_tiles.available
-            data_ok = self._cb_data.isChecked() and avail_data.available
+            flatten_ok = self._cb_flatten.isChecked() and avail_data.available
             flat_ok = tiles_flat_exists
-            enabled = helper_ok and (data_ok or flat_ok)
+            enabled = helper_ok and (flatten_ok or flat_ok)
             self._cb_tiles.setEnabled(enabled)
             if not enabled:
                 self._cb_tiles.setChecked(False)
 
-        self._cb_data.stateChanged.connect(_sync_data_option)
-        self._cb_data.stateChanged.connect(_sync_tiles)
+        self._cb_data_master.clicked.connect(_on_master_clicked)
+        for cb in sub_cbs:
+            cb.clicked.connect(_refresh_master_state)
+        # Flatten controls availability of the explode option and (along with
+        # an on-disk tbl_flat) controls Tiles availability.
+        self._cb_flatten.clicked.connect(_sync_data_option)
+        self._cb_flatten.clicked.connect(_sync_tiles)
+
         _sync_data_option()
         _sync_tiles()
+        _refresh_master_state()
 
         # Button row
         btn_row = QHBoxLayout()
-        self._process_btn = QPushButton("Process selected")
+        self._process_btn = QPushButton("Process")
         self._map_btn = QPushButton("Progress map")
         exit_btn = QPushButton("Exit")
 
@@ -1641,6 +1776,23 @@ class ProcessRunnerWindow(QMainWindow):
         self._process_btn.clicked.connect(self._on_process_click)
         self._map_btn.clicked.connect(self._open_progress_map)
         exit_btn.clicked.connect(self.close)
+
+        # Mode toggle: hide the per-stage grid + rename the button in Normal.
+        def _apply_mode():
+            advanced = self._rb_advanced.isChecked()
+            self._advanced_panel.setVisible(advanced)
+            self._process_btn.setText("Process all selected" if advanced else "Process")
+            self._info_label.setText(
+                "Advanced mode: pick exactly which stages to run. Unavailable "
+                "stages stay disabled. Useful for reruns of a single sub-step."
+                if advanced else
+                "Normal mode: one click runs every stage that has its inputs "
+                "ready. Switch to Advanced to pick individual sub-stages."
+            )
+
+        self._rb_normal.toggled.connect(_apply_mode)
+        self._rb_advanced.toggled.connect(_apply_mode)
+        _apply_mode()
 
         # Connect signals
         self._signals.log_message.connect(self._append_log)
@@ -1763,13 +1915,30 @@ class ProcessRunnerWindow(QMainWindow):
 
     def _worker(self) -> None:
         try:
-            plan = ProcessPlan(
-                run_data=self._cb_data.isChecked(),
-                explode_flat_multipolygons=self._cb_data_explode.isChecked(),
-                run_tiles=self._cb_tiles.isChecked(),
-                run_lines=self._cb_lines.isChecked(),
-                run_analysis=self._cb_analysis.isChecked(),
-            )
+            if self._rb_advanced.isChecked():
+                plan = ProcessPlan(
+                    run_prep=self._cb_prep.isChecked(),
+                    run_intersect=self._cb_intersect.isChecked(),
+                    run_flatten=self._cb_flatten.isChecked(),
+                    explode_flat_multipolygons=self._cb_data_explode.isChecked(),
+                    cleanup_slivers=self._cb_cleanup_slivers.isChecked(),
+                    run_tiles=self._cb_tiles.isChecked(),
+                    run_lines=self._cb_lines.isChecked(),
+                    run_analysis=self._cb_analysis.isChecked(),
+                )
+            else:
+                # Normal mode: run everything available, no advanced toggles.
+                data_on = self._avail_data.available
+                plan = ProcessPlan(
+                    run_prep=data_on,
+                    run_intersect=data_on,
+                    run_flatten=data_on,
+                    explode_flat_multipolygons=False,
+                    cleanup_slivers=True,
+                    run_tiles=self._avail_tiles.available and (data_on or self._tiles_flat_exists),
+                    run_lines=self._avail_lines.available,
+                    run_analysis=self._avail_analysis.available,
+                )
 
             def log_from_worker(msg: str) -> None:
                 self._signals.log_message.emit(msg)
@@ -1821,11 +1990,22 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--list", action="store_true", help="Print availability and exit")
     p.add_argument("--dry-run", action="store_true", help="Print planned actions and exit")
 
-    p.add_argument("--no-data", action="store_true", help="Do not run data processing")
+    p.add_argument("--no-data", action="store_true", help="Do not run any data sub-stage")
+    # Per-sub-stage skips (data processing). Default is to run all three when
+    # --no-data is not set; pass --no-prep / --no-intersect / --no-flatten to
+    # rerun a subset.
+    p.add_argument("--no-prep", action="store_true", help="Skip Prep sub-stage of data processing")
+    p.add_argument("--no-intersect", action="store_true", help="Skip Intersect sub-stage of data processing")
+    p.add_argument("--no-flatten", action="store_true", help="Skip Flatten sub-stage of data processing")
     p.add_argument(
         "--explode-flat-multipolygons",
         action="store_true",
         help="When running data processing, split MultiPolygon geometries in tbl_flat into individual Polygon rows",
+    )
+    p.add_argument(
+        "--no-cleanup-slivers",
+        action="store_true",
+        help="Keep zero-area / sub-1-m^2 sliver rows in tbl_flat (default: drop them)",
     )
     p.add_argument("--no-tiles", action="store_true", help="Do not run raster tiles (MBTiles) after data processing")
     p.add_argument("--no-lines", action="store_true", help="Do not run lines processing")
@@ -1850,10 +2030,14 @@ def main() -> None:
     avail_lines = detect_lines_processing(base_dir, cfg)
     avail_analysis = detect_analysis_processing(base_dir, cfg)
 
+    data_on = avail_data.available and not bool(args.no_data)
     default_plan = ProcessPlan(
-        run_data=avail_data.available and not bool(args.no_data),
+        run_prep=data_on and not bool(args.no_prep),
+        run_intersect=data_on and not bool(args.no_intersect),
+        run_flatten=data_on and not bool(args.no_flatten),
         explode_flat_multipolygons=bool(args.explode_flat_multipolygons),
-        run_tiles=avail_data.available and not bool(args.no_data) and not bool(args.no_tiles),
+        cleanup_slivers=not bool(args.no_cleanup_slivers),
+        run_tiles=data_on and not bool(args.no_tiles),
         run_lines=avail_lines.available and not bool(args.no_lines),
         run_analysis=avail_analysis.available and not bool(args.no_analysis),
     )
@@ -1867,8 +2051,12 @@ def main() -> None:
 
     if args.dry_run:
         selected = []
-        if default_plan.run_data:
-            selected.append("data")
+        if default_plan.run_prep:
+            selected.append("data:prep")
+        if default_plan.run_intersect:
+            selected.append("data:intersect")
+        if default_plan.run_flatten:
+            selected.append("data:flatten")
         if default_plan.run_tiles:
             selected.append("tiles")
         if default_plan.run_lines:

--- a/config.ini
+++ b/config.ini
@@ -62,6 +62,7 @@ h3_max_cells                    = 20000000
 # hosts or after seeing "bad allocation" / OOM crashes during flatten. This
 # cap only applies to partitions >= flatten_large_partition_mb in size.
 flatten_max_workers             = 2
+
 # flatten_small_max_workers: hard cap for the SMALL-partition phase of flatten.
 # Small partitions don't trigger pandas groupby/merge ballooning, so this can
 # and should be much higher (typically near CPU count). 0 = auto.
@@ -69,10 +70,25 @@ flatten_max_workers             = 2
 # evidence that observed per-worker RSS in the small phase stays well under
 # the budget on the largest project this host runs.
 flatten_small_max_workers       = 4
+
 # Disk-size threshold (MB) used to split partitions into "large" and "small"
 # phases. A handful of >50 MB partitions typically dominate memory; everything
 # below runs with wide parallelism. Same value works on macOS and Windows.
 flatten_large_partition_mb      = 50
+
+# Disk-size threshold (MB) above which a partition is treated as HUGE and
+# run strictly serially in its own phase, regardless of flatten_max_workers.
+# Each huge partition can peak at 50-100 GB during pandas groupby/merge.
+flatten_huge_partition_mb       = 200
+# Minimum cell area (m^2) kept in tbl_flat. Cells below this are dropped as
+# slivers (precision artifacts from polygonising asset edges). Set to 0 to
+# disable the cutoff entirely; the UI checkbox can disable it per-run.
+flatten_sliver_min_area_m2      = 1.0
+# Pre-flight refusal thresholds for flatten. If host RAM use or swap is
+# already above these limits when flatten starts, the stage aborts cleanly
+# instead of entering swap-death.
+flatten_preflight_max_vm_percent = 60
+flatten_preflight_max_swap_gb    = 5.0
 # Per-worker RAM estimate used when flatten_max_workers=0. Defaults to roughly
 # 3x approx_gb_per_worker because flatten workers hold whole partitions rather
 # than bounded Stage 2 chunks. Raise this if you still see flatten OOMs.
@@ -112,6 +128,12 @@ stage2_worker_overhead_multiplier = 1.5
 # swap-death. 75 % matches the operator-set ceiling on this host.
 mem_panic_percent              = 75
 mem_panic_grace_secs           = 10
+# Process-lifetime sentinel watchdog. Hard-exits the parent when sustained
+# RAM pressure exceeds the threshold; complements the per-pool watchdog
+# above by covering parent-side work between pools. See learning.md
+# "Parent-side memory in the pipeline" for the failure mode this catches.
+mem_lifetime_panic_percent     = 90
+mem_lifetime_panic_grace_secs  = 5
 
 # -------------------------------------------------------------------------
 # Basic mosaic (basic_mosaic) performance knobs

--- a/config.ini
+++ b/config.ini
@@ -42,7 +42,11 @@ tiles_maxzoom                   = 12
 #
 #
 # Worker processes for CPU-side parallel work: 0=auto. Final worker count is still capped by RAM budget (see approx_gb_per_worker/mem_target_frac) and CPU count.
-max_workers                     = 0
+# Capped at 4 after the 140+ GB peak-RSS event on this M4 Max box - the
+# auto-sized 14-16 worker pool over a dataset with one 664 MB tbl_stacked
+# partition pushed the host into swap-death. Raise only after measuring
+# peak per-worker RSS on a representative project.
+max_workers                     = 4
 # Cap for H3 generation: if estimated H3 cells for the AOI exceed this, H3 levels are skipped to avoid extreme time/RAM use.
 h3_max_cells                    = 20000000
 
@@ -61,7 +65,10 @@ flatten_max_workers             = 2
 # flatten_small_max_workers: hard cap for the SMALL-partition phase of flatten.
 # Small partitions don't trigger pandas groupby/merge ballooning, so this can
 # and should be much higher (typically near CPU count). 0 = auto.
-flatten_small_max_workers       = 0
+# Pinned at 4 to match the global 4-worker safety cap; raise when we have
+# evidence that observed per-worker RSS in the small phase stays well under
+# the budget on the largest project this host runs.
+flatten_small_max_workers       = 4
 # Disk-size threshold (MB) used to split partitions into "large" and "small"
 # phases. A handful of >50 MB partitions typically dominate memory; everything
 # below runs with wide parallelism. Same value works on macOS and Windows.
@@ -74,14 +81,37 @@ flatten_approx_gb_per_worker    = 12.0
 # into tbl_stacked partitions. This phase is I/O-bound and pandas-merge-light,
 # so it can run with far more parallelism than flatten. 0 = auto. Safe to
 # raise on Windows/Linux hosts with many cores and ample RAM.
-backfill_max_workers            = 0
+# Pinned at 4 to match the global 4-worker safety cap.
+backfill_max_workers            = 4
 # tiles_max_workers: hard cap for the MBTiles raster generation stage. Each
 # worker holds a pickled copy of the current group's geometry list, so RAM
 # scales with both workers and group size. 0 = auto (CPU/2 clipped by RAM
 # budget). Raise on Windows/Linux hosts with lots of RAM and many cores.
-tiles_max_workers               = 0
+# Pinned at 4 to match the global 4-worker safety cap.
+tiles_max_workers               = 4
 # Per-worker RAM estimate for tiles generation, used when tiles_max_workers=0.
 tiles_approx_gb_per_worker      = 3.0
+# Stage 2 (tbl_stacked) worker count is capped using
+#   max(approx_gb_per_worker, data_gb * stage2_worker_overhead_multiplier).
+# The default 1.5 covers the worst case: each worker holds full assets +
+# geocodes plus spatial index buffers, and an sjoin against a dense asset
+# region can multiply geocode rows several-fold inside a single chunk. We
+# briefly tried 1.0 on this M4 Max (5 GB observed vs 5.6 GB data) and it
+# produced a 140+ GB peak-RSS swap stall on a large project, because
+# psutil's "available" reading on Apple Silicon stays optimistic right up
+# until the OS starts paging. The code now floors this at 1.0 regardless;
+# leave at 1.5 unless you have measured peak worker RSS and have headroom.
+stage2_worker_overhead_multiplier = 1.5
+
+# Memory panic watchdog. If RAM use crosses mem_panic_percent and stays
+# there for mem_panic_grace_secs, the active multiprocessing pool (Stage 2
+# intersect, flatten-large, flatten-small, or backfill) is terminated and
+# the run aborts cleanly with an error. Catches the case where the
+# pre-flight worker estimate underestimates a particular chunk's join or
+# pandas-merge expansion, before macOS unified memory falls into
+# swap-death. 75 % matches the operator-set ceiling on this host.
+mem_panic_percent              = 75
+mem_panic_grace_secs           = 10
 
 # -------------------------------------------------------------------------
 # Basic mosaic (basic_mosaic) performance knobs
@@ -172,7 +202,12 @@ asset_soft_limit                = 100000
 # Estimated RAM use per worker (GB). Higher value => fewer workers chosen when max_workers=0
 approx_gb_per_worker            = 4.0
 # Fraction of available RAM to treat as usable budget when auto-sizing work (0.0-1.0)
-# Apple Silicon uses unified memory (GPU + CPU share RAM), so keep more headroom here.
+# Apple Silicon uses unified memory (GPU + CPU share RAM). 0.70 is the safe
+# default when other apps share the machine; 0.85 was tried during the
+# Apple Silicon tuning pass but produced a 140+ GB peak-RSS swap stall on
+# a large project (psutil's "available" stays optimistic on unified memory
+# right up until the OS pages out). Back to 0.70 to keep peak under the
+# 75 % mem_panic_percent ceiling.
 mem_target_frac                 = 0.70
 # Seconds between “still working” pings in long-running operations (smaller = more frequent logs)
 heartbeat_secs                  = 60

--- a/learning.md
+++ b/learning.md
@@ -391,3 +391,21 @@ When a problem is solved, add a short entry here with:
   - Large auxiliary DataFrames (e.g. `area_map`) are persisted to a scratch parquet (`__area_map.parquet`) before the pool spawns, so workers read it lazily instead of inheriting a pickled copy across every spawn boundary. This cuts driver-process RSS by several GB per run.
 - Non-regression guarantee:
   - All four caps default to `0 = auto`. With no config changes and no psutil, the code paths fall back to the same CPU-based heuristic used previously. Existing Windows baselines are only affected if the user explicitly opts in by setting the new keys or by adopting the updated `config.ini` defaults.
+
+## Parent-side memory in the pipeline (2026-04-26)
+
+- Rule:
+  - In `code/processing_internal.py`, the parent process must never materialise a known-large dataset (`tbl_stacked`, `tbl_flat`, similar partitioned outputs) into a single in-process `(Geo)DataFrame`. This applies most strictly to the windows *between* worker pools (e.g. between intersect and flatten), where no panic watchdog is alive.
+  - For row counts: use `pyarrow.dataset.dataset(<path>).count_rows()` or reuse the count already logged by `intersect_assets_geocodes` ("tbl_stacked dataset written as folder with N parts and ~M rows").
+  - For presence checks: glob the partition directory.
+  - For actual data work on these tables: read inside a worker process.
+- Why:
+  - Three previous memory fixes on this branch (`99e5956` → `8b878c5` → `ba24a32`) all bolted guards onto worker pools - per-pool watchdog, per-stage worker caps, three-phase huge/large/small flatten split, flatten pre-flight RAM/swap check. All correct, all scoped to *inside* `Pool(...)` blocks.
+  - The April-26 incident was caused by a 4-line "post-intersect cleanup" debug log added in the unguarded gap between intersect's pool and flatten's pool: `sample = read_parquet_or_empty("tbl_stacked"); log_to_gui(... f"tbl_stacked rows (sample read): {len(sample):,}")`. `read_parquet_or_empty()` resolves a partitioned directory to `gpd.read_parquet(<dir>)`, which materialises the entire dataset (1363 parts, 92,430,523 rows, geometries included) into the parent's RSS - tens of GB on top of the ~10 GB of intersect residue. None of the existing watchdogs fired because none were running in that window. The host swap-stalled; the process eventually died with no flatten log lines and no `tbl_flat`.
+  - The variable was named `sample`. It was not a sample. The row count it printed was already in the log 11 seconds earlier.
+- How to apply:
+  - Before adding any read in `process_tbl_stacked`, `flatten_tbl_stacked`, `intersect_assets_geocodes`, or any code that runs in the parent between stages, check: "is this materialising a known-large dataset?" If yes, replace with a glob (presence), `count_rows()` (count), or move it inside a worker.
+  - The new `_start_lifetime_panic_watchdog()` (started by `run_processing_pipeline`, default 90% RAM for 5s → `os._exit(137)`) is a backstop that frees the host but kills the run's progress. Treat it as a smoke alarm, not a fire suppression system - it is not a substitute for not making the allocation in the first place.
+  - The docstring on `read_parquet_or_empty()` carries the same warning. Read it before calling.
+- Non-regression guarantee:
+  - The fix replaces the offending block with `len(list(ds_dir.glob("*.parquet")))` and adds the lifetime watchdog with conservative defaults (90%/5s) wired through `mem_lifetime_panic_percent` / `mem_lifetime_panic_grace_secs`. Existing per-pool watchdogs, per-stage caps, three-phase split, and pre-flight checks are unchanged. Windows baseline behaviour is unaffected unless `psutil` is available and pressure crosses the new lifetime threshold (which it should not under normal operation).


### PR DESCRIPTION
## Summary
- Memory panic watchdog (per-pool + process-lifetime backstop) and pipeline worker caps after the 140+ GB peak-RSS swap stall on M4 Max
- Pipeline parent-side memory fix, stage selectors (Prep/Intersect/Flatten) + sliver cleanup
- Asset import: optional "Dissolve adjacent polygons" checkbox + hardened dissolve with per-stage progress and final summary

## Commits
- ba24a32 Add memory panic watchdog; cap pipeline workers at 4
- 8a3f07b Pipeline: fix parent-side memory regression, add stage selectors and sliver cleanup
- 9b98d98 asset_manage: optional dissolve of adjacent same-attribute polygons on import
- d204868 asset_manage: harden dissolve, add per-stage progress + final summary