### PR TITLE
pipeline + mesa: reliability, ZSTD parquet, threaded backup, Welcome tab

### DIFF
--- a/code/processing_internal.py
+++ b/code/processing_internal.py
@@ -1187,7 +1187,7 @@ def read_parquet_or_empty(name: str) -> gpd.GeoDataFrame:
 
 def write_parquet(name: str, gdf: gpd.GeoDataFrame):
     path = gpq_dir() / f"{name}.parquet"
-    gdf.to_parquet(path, index=False)
+    gdf.to_parquet(path, index=False, compression="zstd", compression_level=3)
     log_to_gui(log_widget, f"Wrote {path}")
 
 def _rm_rf(path: Path):
@@ -1281,7 +1281,7 @@ def write_data_extent(working_epsg: int) -> None:
         crs=working_epsg,
     )
     out_path = gpq_dir() / "tbl_data_extent.parquet"
-    out.to_parquet(out_path, index=False)
+    out.to_parquet(out_path, index=False, compression="zstd", compression_level=3)
     try:
         n_polys = len(union.geoms) if union.geom_type == 'MultiPolygon' else 1
     except Exception:
@@ -1335,7 +1335,7 @@ def _grid_worker(input_path: str) -> str:
     try: j = j[j.geometry.notna() & ~j.geometry.is_empty]
     except Exception: pass
     out = _GRID_OUT_DIR / f"grid_tag_{os.getpid()}_{uuid.uuid4().hex}.parquet"
-    j.to_parquet(out, index=False)
+    j.to_parquet(out, index=False, compression="zstd", compression_level=3)
     del g, j
     gc.collect()
     return str(out)
@@ -1581,7 +1581,7 @@ def assign_geocodes_to_grid(geodata: gpd.GeoDataFrame, meters_cell: int, max_wor
     for i in range(0, len(geodata), rows_per_chunk):
         part = geodata.iloc[i:i+rows_per_chunk]
         p = tmp_in / f"geo_{i:09d}.parquet"
-        part.to_parquet(p, index=False)
+        part.to_parquet(p, index=False, compression="zstd", compression_level=3)
         input_parts.append(str(p))
 
     started_at = time.time(); last_ping = started_at
@@ -1860,7 +1860,7 @@ def _intersection_worker(args):
                     pass
             fname = f"part_{os.getpid()}_{uuid.uuid4().hex}.parquet"
             path = _PARTS_DIR / fname
-            gdf.to_parquet(path, index=False)
+            gdf.to_parquet(path, index=False, compression="zstd", compression_level=3)
             gc.collect()
             return [str(path)]
         except Exception:
@@ -2947,7 +2947,9 @@ def _backfill_worker(args):
         if 'area_m2_flat' in merged.columns:
             merged['area_m2'] = merged['area_m2_flat']
             merged.drop(columns=['area_m2_flat'], inplace=True)
-        gpd.GeoDataFrame(merged, geometry=part.geometry.name, crs=part.crs).to_parquet(path, index=False)
+        gpd.GeoDataFrame(merged, geometry=part.geometry.name, crs=part.crs).to_parquet(
+            path, index=False, compression="zstd", compression_level=3,
+        )
         return len(part)
     except Exception:
         return 0
@@ -3749,7 +3751,7 @@ def backfill_tbl_stacked(config_file: Path,
     # whole DataFrame across every spawn boundary.
     area_map_path = gpq_dir() / "__area_map.parquet"
     try:
-        area_map.to_parquet(area_map_path, index=False)
+        area_map.to_parquet(area_map_path, index=False, compression="zstd", compression_level=3)
         worker_area_arg = area_map_path
     except Exception as e:
         log_to_gui(log_widget,

--- a/code/processing_pipeline_run.py
+++ b/code/processing_pipeline_run.py
@@ -38,9 +38,11 @@ from PySide6.QtCore import Qt, QTimer, Signal, QObject
 from asset_manage import apply_shared_stylesheet
 
 import argparse
+import atexit
 import configparser
 import datetime
 import os
+import shutil
 import subprocess
 import sys
 import threading
@@ -260,6 +262,56 @@ def _log_line(base_dir: Path, log_fn: Callable[[str], None], msg: str) -> None:
         pass
 
 
+def _caffeinate_start(
+    base_dir: Path,
+    cfg: configparser.ConfigParser,
+    log_fn: Callable[[str], None],
+) -> subprocess.Popen | None:
+    # macOS-only: hold sleep / App Nap / IO-throttle assertions for the duration
+    # of the pipeline run. -w <pid> makes caffeinate self-terminate if mesa.py
+    # dies before _caffeinate_stop() runs.
+    if sys.platform != "darwin":
+        return None
+    try:
+        if not cfg.getboolean("DEFAULT", "macos_caffeinate", fallback=True):
+            return None
+    except Exception:
+        return None
+    try:
+        proc = subprocess.Popen(
+            ["caffeinate", "-dimsu", "-w", str(os.getpid())],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        _log_line(base_dir, log_fn,
+                  f"[caffeinate] holding -dimsu assertions (pid {proc.pid})")
+        return proc
+    except FileNotFoundError:
+        _log_line(base_dir, log_fn, "[caffeinate] /usr/bin/caffeinate not found; skipping")
+        return None
+    except Exception as exc:
+        _log_line(base_dir, log_fn, f"[caffeinate] failed to start: {exc}")
+        return None
+
+
+def _caffeinate_stop(
+    base_dir: Path,
+    proc: subprocess.Popen | None,
+    log_fn: Callable[[str], None],
+) -> None:
+    if proc is None:
+        return
+    try:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        _log_line(base_dir, log_fn, "[caffeinate] released")
+    except Exception:
+        pass
+
+
 def _run_subprocess_streaming(
     base_dir: Path,
     log_fn: Callable[[str], None],
@@ -268,6 +320,7 @@ def _run_subprocess_streaming(
     env: dict[str, str] | None = None,
     line_prefix: str = "[child]",
 ) -> int:
+    prefix = line_prefix or "[child]"
     try:
         _log_line(base_dir, log_fn, "Running: " + " ".join(argv))
         proc = subprocess.Popen(
@@ -281,14 +334,51 @@ def _run_subprocess_streaming(
             errors="replace",
             bufsize=1,
         )
-        if proc.stdout:
-            prefix = line_prefix or ""
-            for line in proc.stdout:
-                if line:
-                    _log_line(base_dir, log_fn, f"{prefix} {line.rstrip()}".rstrip())
-                else:
-                    _log_line(base_dir, log_fn, prefix)
-        proc.wait()
+
+        # Watchdog: poll the global cancel flag; terminate (then kill) the
+        # child as soon as the operator requests cancel, so we don't have to
+        # wait for it to finish on its own.
+        watch_stop = threading.Event()
+        was_cancelled = {"flag": False}
+
+        def _cancel_watcher() -> None:
+            while not watch_stop.wait(0.5):
+                try:
+                    import processing_internal as dpi
+                    if dpi.is_cancelled():
+                        was_cancelled["flag"] = True
+                        try:
+                            proc.terminate()
+                            try:
+                                proc.wait(timeout=2.0)
+                            except subprocess.TimeoutExpired:
+                                try:
+                                    proc.kill()
+                                except Exception:
+                                    pass
+                        except Exception:
+                            pass
+                        return
+                except Exception:
+                    pass
+
+        watcher = threading.Thread(target=_cancel_watcher, daemon=True)
+        watcher.start()
+        try:
+            if proc.stdout:
+                for line in proc.stdout:
+                    if line:
+                        _log_line(base_dir, log_fn, f"{prefix} {line.rstrip()}".rstrip())
+                    else:
+                        _log_line(base_dir, log_fn, prefix)
+            proc.wait()
+        finally:
+            watch_stop.set()
+
+        if was_cancelled["flag"]:
+            _log_line(base_dir, log_fn,
+                      f"{prefix} subprocess terminated due to cancel request")
+            return 130
         if proc.returncode != 0:
             _log_line(base_dir, log_fn, f"ERROR: process failed (exit={proc.returncode})")
         return int(proc.returncode or 0)
@@ -1460,6 +1550,95 @@ def run_analysis_process(
 # ---------------------------------------------------------------------------
 
 
+_STAGE_NAMES: tuple[str, ...] = ("data", "tiles", "lines", "analysis")
+
+# First-run fallback. Units are arbitrary but proportional to typical wall
+# clock seconds, tuned from observed MESA runs (tiles is the dominant stage,
+# not the lightest as the previous static table claimed). After the first
+# real run, observed durations from tbl_stage_runtime replace these.
+_DEFAULT_STAGE_WEIGHTS: dict[str, float] = {
+    "data": 600.0,
+    "tiles": 1200.0,
+    "lines": 180.0,
+    "analysis": 300.0,
+}
+
+
+def _stage_runtime_path(base_dir: Path) -> Path:
+    return base_dir / "output" / "geoparquet" / "tbl_stage_runtime.parquet"
+
+
+def _read_recent_stage_durations(
+    base_dir: Path, *, recent_n: int = 5
+) -> dict[str, float]:
+    """Return mean duration_seconds per stage from the most recent clean
+    completions. Missing stages are absent from the result; the caller is
+    expected to fall back to _DEFAULT_STAGE_WEIGHTS for those."""
+    path = _stage_runtime_path(base_dir)
+    if not path.exists():
+        return {}
+    try:
+        import pandas as pd
+        df = pd.read_parquet(path)
+    except Exception:
+        return {}
+    if df.empty or "stage" not in df.columns or "duration_seconds" not in df.columns:
+        return {}
+    if "had_error" in df.columns:
+        df = df[~df["had_error"].astype(bool)]
+    if "was_cancelled" in df.columns:
+        df = df[~df["was_cancelled"].astype(bool)]
+    if df.empty:
+        return {}
+    out: dict[str, float] = {}
+    for stage, sub in df.groupby("stage"):
+        if "started_utc" in sub.columns:
+            sub = sub.sort_values("started_utc").tail(recent_n)
+        else:
+            sub = sub.tail(recent_n)
+        try:
+            mean = float(sub["duration_seconds"].mean())
+        except Exception:
+            continue
+        if mean > 0:
+            out[str(stage)] = mean
+    return out
+
+
+def _append_stage_runtime(
+    base_dir: Path,
+    rows: list[dict],
+    log_fn: Callable[[str], None],
+) -> None:
+    """Append measured per-stage durations to the per-project learning
+    table. Tolerates a missing pandas import or a corrupt file by logging a
+    one-line warning and giving up - this is purely a learning cache."""
+    if not rows:
+        return
+    try:
+        import pandas as pd
+    except Exception:
+        return
+    path = _stage_runtime_path(base_dir)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        _log_line(base_dir, log_fn,
+                  f"WARNING: cannot create {path.parent} for stage runtime: {e}")
+        return
+    new_df = pd.DataFrame(rows)
+    try:
+        if path.exists():
+            existing = pd.read_parquet(path)
+            combined = pd.concat([existing, new_df], ignore_index=True)
+        else:
+            combined = new_df
+        combined.to_parquet(path, index=False)
+    except Exception as e:
+        _log_line(base_dir, log_fn,
+                  f"WARNING: could not write stage runtime history ({path.name}): {e}")
+
+
 def run_selected(
     base_dir: Path,
     cfg: configparser.ConfigParser,
@@ -1481,15 +1660,81 @@ def run_selected(
 
     had_errors = False
     _log_line(base_dir, log_fn, "[Process] STARTED")
+    caf = _caffeinate_start(base_dir, cfg, log_fn)
 
-    # Weighted progress allocation (normalized across selected processes).
-    # This provides more realistic overall movement than fixed 25% blocks.
+    # Inter-stage cancel gate. Without this, a cancel that fires inside e.g.
+    # the Data stage gets absorbed by the per-stage `except Exception` below
+    # and the next stage starts anyway. Call _bail_if_cancelled() between
+    # stages so cancel actually stops the pipeline.
+    def _is_cancelled() -> bool:
+        try:
+            import processing_internal as dpi
+            return bool(dpi.is_cancelled())
+        except Exception:
+            return False
+
+    def _bail_if_cancelled() -> None:
+        if not _is_cancelled():
+            return
+        try:
+            import processing_internal as dpi
+            raise getattr(dpi, "ProcessingCancelled", RuntimeError)("Cancelled by operator")
+        except ImportError:
+            raise RuntimeError("Cancelled by operator")
+
+    # If tiles step is unchecked but old tiles are on disk, wipe them so they
+    # cannot silently misalign with the new processing results. The UI surfaces
+    # this with a warning next to the unchecked Tiles checkbox.
+    if not plan.run_tiles:
+        mbt_dir = base_dir / "output" / "mbtiles"
+        try:
+            stale = list(mbt_dir.glob("*.mbtiles")) if mbt_dir.is_dir() else []
+        except OSError:
+            stale = []
+        if stale:
+            try:
+                shutil.rmtree(mbt_dir)
+                _log_line(base_dir, log_fn,
+                          f"[Process] Tiles unchecked: removed {len(stale)} stale "
+                          f"mbtiles file(s) from {mbt_dir}")
+            except OSError as exc:
+                _log_line(base_dir, log_fn,
+                          f"WARNING: could not remove stale tiles in {mbt_dir}: {exc}")
+
+    # Weighted progress allocation, calibrated from this project's own
+    # history. _read_recent_stage_durations returns mean seconds per stage
+    # from the last few clean completions; _DEFAULT_STAGE_WEIGHTS fills in
+    # any stage we haven't observed yet. After each successful run we append
+    # measured durations to tbl_stage_runtime.parquet so subsequent runs get
+    # progressively more accurate proportions.
+    observed = _read_recent_stage_durations(base_dir)
     weights: dict[str, float] = {
-        "data": 4.0,
-        "tiles": 1.0,
-        "lines": 2.5,
-        "analysis": 2.5,
+        name: float(observed.get(name) or _DEFAULT_STAGE_WEIGHTS.get(name, 1.0))
+        for name in _STAGE_NAMES
     }
+    if observed:
+        seen = ", ".join(f"{n}={observed[n]:.0f}s" for n in _STAGE_NAMES if n in observed)
+        _log_line(base_dir, log_fn,
+                  f"[Process] Progress weights from history: {seen}")
+
+    # Per-stage runtime measurements. Appended to tbl_stage_runtime at the
+    # end of the run so future runs can self-calibrate.
+    run_id = uuid.uuid4().hex[:12]
+    runtime_rows: list[dict] = []
+
+    def _record_stage(stage: str, started_iso: str, t0: float,
+                      had_error: bool) -> None:
+        try:
+            runtime_rows.append({
+                "run_id": run_id,
+                "stage": stage,
+                "started_utc": started_iso,
+                "duration_seconds": float(time.monotonic() - t0),
+                "had_error": bool(had_error),
+                "was_cancelled": _is_cancelled(),
+            })
+        except Exception:
+            pass
 
     total_weight = sum(weights.get(name, 1.0) for name in active)
     if total_weight <= 0:
@@ -1516,71 +1761,114 @@ def run_selected(
 
         return _slice
 
-    if plan.run_data:
-        try:
-            s, e = ranges.get("data", (0.0, 100.0))
-            sub_summary = ", ".join([
-                name for name, on in [("prep", plan.run_prep),
-                                       ("intersect", plan.run_intersect),
-                                       ("flatten", plan.run_flatten),
-                                       ("backfill", plan.run_backfill)]
-                if on
-            ]) or "(none)"
-            _log_line(base_dir, log_fn,
-                      f"[Process] Progress range data: {s:.1f}% -> {e:.1f}% (sub-stages: {sub_summary})")
-            run_data_process(
-                base_dir,
-                log_fn,
-                make_slice_progress(s, e),
-                explode_flat_multipolygons=bool(plan.explode_flat_multipolygons),
-                run_prep=bool(plan.run_prep),
-                run_intersect=bool(plan.run_intersect),
-                run_flatten=bool(plan.run_flatten),
-                run_backfill=bool(plan.run_backfill),
-                cleanup_slivers=bool(plan.cleanup_slivers),
-            )
-        except Exception as exc:
-            _log_line(base_dir, log_fn, f"ERROR: data processing failed: {exc}")
-            had_errors = True
+    def _now_iso() -> str:
+        return datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
 
-    if plan.run_tiles:
-        try:
-            s, e = ranges.get("tiles", (0.0, 100.0))
-            _log_line(base_dir, log_fn, f"[Process] Progress range tiles: {s:.1f}% -> {e:.1f}%")
-            gpq = parquet_dir(base_dir, cfg)
-            if not _exists_any([gpq / "tbl_flat.parquet"]):
-                # Soft skip: user opted in to tiles but the upstream artifact
-                # is not on disk. Honour the rerun-parts intent rather than
-                # failing the whole batch.
+    try:
+        _bail_if_cancelled()
+        if plan.run_data:
+            _t0 = time.monotonic()
+            _started_iso = _now_iso()
+            _err = False
+            try:
+                s, e = ranges.get("data", (0.0, 100.0))
+                sub_summary = ", ".join([
+                    name for name, on in [("prep", plan.run_prep),
+                                           ("intersect", plan.run_intersect),
+                                           ("flatten", plan.run_flatten),
+                                           ("backfill", plan.run_backfill)]
+                    if on
+                ]) or "(none)"
                 _log_line(base_dir, log_fn,
-                          "Tiles: skipped - tbl_flat.parquet is missing. "
-                          "Run Flatten (or Data processing end-to-end) first.")
-            else:
-                run_tiles_process(base_dir, cfg, log_fn, make_slice_progress(s, e))
-        except Exception as exc:
-            _log_line(base_dir, log_fn, f"ERROR: raster tiles failed: {exc}")
-            had_errors = True
+                          f"[Process] Progress range data: {s:.1f}% -> {e:.1f}% (sub-stages: {sub_summary})")
+                run_data_process(
+                    base_dir,
+                    log_fn,
+                    make_slice_progress(s, e),
+                    explode_flat_multipolygons=bool(plan.explode_flat_multipolygons),
+                    run_prep=bool(plan.run_prep),
+                    run_intersect=bool(plan.run_intersect),
+                    run_flatten=bool(plan.run_flatten),
+                    run_backfill=bool(plan.run_backfill),
+                    cleanup_slivers=bool(plan.cleanup_slivers),
+                )
+            except Exception as exc:
+                if not _is_cancelled():
+                    _err = True
+                    _log_line(base_dir, log_fn, f"ERROR: data processing failed: {exc}")
+                    had_errors = True
+            finally:
+                _record_stage("data", _started_iso, _t0, _err)
 
-    if plan.run_lines:
-        try:
-            s, e = ranges.get("lines", (0.0, 100.0))
-            _log_line(base_dir, log_fn, f"[Process] Progress range lines: {s:.1f}% -> {e:.1f}%")
-            run_lines_process(base_dir, cfg, log_fn, make_slice_progress(s, e))
-        except Exception as exc:
-            _log_line(base_dir, log_fn, f"ERROR: lines processing failed: {exc}")
-            had_errors = True
+        _bail_if_cancelled()
+        if plan.run_tiles:
+            _t0 = time.monotonic()
+            _started_iso = _now_iso()
+            _err = False
+            try:
+                s, e = ranges.get("tiles", (0.0, 100.0))
+                _log_line(base_dir, log_fn, f"[Process] Progress range tiles: {s:.1f}% -> {e:.1f}%")
+                gpq = parquet_dir(base_dir, cfg)
+                if not _exists_any([gpq / "tbl_flat.parquet"]):
+                    # Soft skip: user opted in to tiles but the upstream artifact
+                    # is not on disk. Honour the rerun-parts intent rather than
+                    # failing the whole batch.
+                    _log_line(base_dir, log_fn,
+                              "Tiles: skipped - tbl_flat.parquet is missing. "
+                              "Run Flatten (or Data processing end-to-end) first.")
+                else:
+                    run_tiles_process(base_dir, cfg, log_fn, make_slice_progress(s, e))
+            except Exception as exc:
+                if not _is_cancelled():
+                    _err = True
+                    _log_line(base_dir, log_fn, f"ERROR: raster tiles failed: {exc}")
+                    had_errors = True
+            finally:
+                _record_stage("tiles", _started_iso, _t0, _err)
 
-    if plan.run_analysis:
-        try:
-            s, e = ranges.get("analysis", (0.0, 100.0))
-            _log_line(base_dir, log_fn, f"[Process] Progress range analysis: {s:.1f}% -> {e:.1f}%")
-            run_analysis_process(base_dir, cfg, log_fn, make_slice_progress(s, e))
-        except Exception as exc:
-            _log_line(base_dir, log_fn, f"ERROR: analysis processing failed: {exc}")
-            had_errors = True
+        _bail_if_cancelled()
+        if plan.run_lines:
+            _t0 = time.monotonic()
+            _started_iso = _now_iso()
+            _err = False
+            try:
+                s, e = ranges.get("lines", (0.0, 100.0))
+                _log_line(base_dir, log_fn, f"[Process] Progress range lines: {s:.1f}% -> {e:.1f}%")
+                run_lines_process(base_dir, cfg, log_fn, make_slice_progress(s, e))
+            except Exception as exc:
+                if not _is_cancelled():
+                    _err = True
+                    _log_line(base_dir, log_fn, f"ERROR: lines processing failed: {exc}")
+                    had_errors = True
+            finally:
+                _record_stage("lines", _started_iso, _t0, _err)
 
-    progress_fn(100.0)
-    _log_line(base_dir, log_fn, "[Process] FAILED" if had_errors else "[Process] COMPLETED")
+        _bail_if_cancelled()
+        if plan.run_analysis:
+            _t0 = time.monotonic()
+            _started_iso = _now_iso()
+            _err = False
+            try:
+                s, e = ranges.get("analysis", (0.0, 100.0))
+                _log_line(base_dir, log_fn, f"[Process] Progress range analysis: {s:.1f}% -> {e:.1f}%")
+                run_analysis_process(base_dir, cfg, log_fn, make_slice_progress(s, e))
+            except Exception as exc:
+                if not _is_cancelled():
+                    _err = True
+                    _log_line(base_dir, log_fn, f"ERROR: analysis processing failed: {exc}")
+                    had_errors = True
+            finally:
+                _record_stage("analysis", _started_iso, _t0, _err)
+
+        _bail_if_cancelled()
+        progress_fn(100.0)
+        _log_line(base_dir, log_fn, "[Process] FAILED" if had_errors else "[Process] COMPLETED")
+    finally:
+        # Always persist what we measured and release caffeinate, even if a
+        # cancel raised mid-pipeline. The learning table filters out cancelled
+        # / errored rows when computing future weights.
+        _append_stage_runtime(base_dir, runtime_rows, log_fn)
+        _caffeinate_stop(base_dir, caf, log_fn)
 
 
 # ---------------------------------------------------------------------------
@@ -1630,6 +1918,9 @@ class ProcessRunnerWindow(QMainWindow):
         self._cfg = cfg
         self._signals = _RunnerSignals()
         self._tail_state: dict[str, int] = {}
+        # Flips True when the current run ended via operator cancel, so
+        # _on_task_finished can show a distinct terminal state.
+        self._was_cancelled: bool = False
 
         self.setWindowTitle("MESA \u2013 Process all")
         self.resize(1100, 600)
@@ -1800,23 +2091,28 @@ class ProcessRunnerWindow(QMainWindow):
                     "; ".join(avail.reasons) if avail.reasons else "Missing inputs")
             lbl = QLabel(status)
             lbl.setWordWrap(True)
+            # Stash the resting status text so transient warnings can be restored.
+            lbl.setProperty("normal_text", status)
             grid.addWidget(lbl, row, 4)
             if not avail.available:
                 cb.setEnabled(False)
                 cb.setChecked(False)
-            return cb
+            return cb, lbl
 
         tiles_status = "Run Flatten (or full data) first" if not tiles_flat_exists else None
-        self._cb_tiles    = _mk_row_right(1, "5. Tiles processing (MBTiles)",
-                                          tiles_default, avail_tiles,
-                                          "Re-renders from tbl_flat",
-                                          tiles_status)
-        self._cb_lines    = _mk_row_right(2, "6. Lines processing (segments)",
-                                          avail_lines.available, avail_lines,
-                                          "Re-aggregates from tbl_flat")
-        self._cb_analysis = _mk_row_right(3, "7. Analysis processing (study areas)",
-                                          avail_analysis.available, avail_analysis,
-                                          "Consumes tbl_flat")
+        self._cb_tiles, self._lbl_tiles = _mk_row_right(
+            1, "5. Tiles processing (MBTiles)",
+            tiles_default, avail_tiles,
+            "Re-renders from tbl_flat",
+            tiles_status)
+        self._cb_lines, _ = _mk_row_right(
+            2, "6. Lines processing (segments)",
+            avail_lines.available, avail_lines,
+            "Re-aggregates from tbl_flat")
+        self._cb_analysis, _ = _mk_row_right(
+            3, "7. Analysis processing (study areas)",
+            avail_analysis.available, avail_analysis,
+            "Consumes tbl_flat")
 
         # Options under the grid (spans all columns) so they're clearly the
         # flatten / data options, not specific to either stage column.
@@ -1875,6 +2171,24 @@ class ProcessRunnerWindow(QMainWindow):
             if not enabled:
                 self._cb_tiles.setChecked(False)
 
+        def _sync_tiles_warning():
+            # Show a red warning next to the Tiles checkbox when leaving it
+            # unchecked would cause existing tiles to be deleted at run start.
+            mbt_dir = base_dir / "output" / "mbtiles"
+            try:
+                has_existing = mbt_dir.is_dir() and any(mbt_dir.glob("*.mbtiles"))
+            except OSError:
+                has_existing = False
+            if (not self._cb_tiles.isChecked()) and has_existing:
+                self._lbl_tiles.setText(
+                    "Existing tiles in output/mbtiles will be DELETED at run start "
+                    "to keep them aligned with new processing results."
+                )
+                self._lbl_tiles.setStyleSheet("color: #b34a00; font-weight: bold;")
+            else:
+                self._lbl_tiles.setText(self._lbl_tiles.property("normal_text") or "")
+                self._lbl_tiles.setStyleSheet("")
+
         self._cb_data_master.clicked.connect(_on_master_clicked)
         for cb in sub_cbs:
             cb.clicked.connect(_refresh_master_state)
@@ -1882,9 +2196,12 @@ class ProcessRunnerWindow(QMainWindow):
         # an on-disk tbl_flat) controls Tiles availability.
         self._cb_flatten.clicked.connect(_sync_data_option)
         self._cb_flatten.clicked.connect(_sync_tiles)
+        # Tiles toggle drives the stale-tiles warning text.
+        self._cb_tiles.clicked.connect(_sync_tiles_warning)
 
         _sync_data_option()
         _sync_tiles()
+        _sync_tiles_warning()
         _refresh_master_state()
 
         # Button row
@@ -1983,10 +2300,20 @@ class ProcessRunnerWindow(QMainWindow):
 
     def _on_task_finished(self) -> None:
         self._process_btn.setEnabled(True)
+        self._process_btn.setText(
+            "Process all selected" if self._rb_advanced.isChecked() else "Process"
+        )
         self._pause_btn.setText("Pause")
         self._pause_btn.setEnabled(False)
         self._cancel_btn.setText("Cancel")
         self._cancel_btn.setEnabled(False)
+        if self._was_cancelled:
+            # Mark a clean terminal state in the UI so the operator sees that
+            # the cancel actually took effect, instead of the label sitting on
+            # "Cancelling…" forever. Reset the progress bar so it doesn't look
+            # like the run was almost done.
+            self._progress_bar.setValue(0)
+            self._append_log(f"{_ts()} - ————— RUN CANCELLED. READY FOR A NEW RUN. —————")
         # Resume log-file tailing; skip to current EOF so we don't replay
         # lines already shown via the worker's direct signal path.
         log_path = self._base_dir / "log.txt"
@@ -2127,12 +2454,14 @@ class ProcessRunnerWindow(QMainWindow):
                 )
                 return  # button stays enabled so the operator can retry
         self._process_btn.setEnabled(False)
+        self._process_btn.setText("Processing…")
         # Reset pause/cancel state for the new run and enable the controls.
         try:
             import processing_internal as dpi
             dpi.reset_run_state()
         except Exception:
             pass
+        self._was_cancelled = False
         self._pause_btn.setText("Pause")
         self._pause_btn.setEnabled(True)
         self._cancel_btn.setText("Cancel")
@@ -2207,6 +2536,7 @@ class ProcessRunnerWindow(QMainWindow):
             except Exception:
                 cancelled_cls = None
             if cancelled_cls is not None and isinstance(e, cancelled_cls):
+                self._was_cancelled = True
                 self._signals.log_message.emit(f"{_ts()} - PROCESSING CANCELLED BY OPERATOR")
             else:
                 self._signals.log_message.emit(f"{_ts()} - ERROR: {e}")
@@ -2282,6 +2612,80 @@ def run(base_dir: str, master=None) -> None:
     return run_ui(resolved, cfg, master=master)
 
 
+def _acquire_pipeline_lock(base_dir: Path) -> tuple[bool, str | None]:
+    """Single-instance lockfile for the processing pipeline.
+
+    Two pipeline subprocesses writing to the same project share one log.txt
+    and one set of geoparquet outputs; the log becomes unreadable and the
+    outputs race each other. Refuse a second concurrent run.
+
+    Stale locks (process crashed without cleanup) are detected via PID
+    liveness and silently reclaimed.
+    """
+    lock_path = base_dir / "output" / ".pipeline.lock"
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        return False, f"cannot create {lock_path.parent}: {e}"
+
+    if lock_path.exists():
+        try:
+            content = lock_path.read_text(encoding="utf-8").strip()
+            existing_pid = int(content.split("\n", 1)[0])
+            try:
+                os.kill(existing_pid, 0)
+                holder = f"PID {existing_pid}"
+                rest = content.split("\n", 1)[1] if "\n" in content else ""
+                if rest:
+                    holder = f"{holder} (started {rest})"
+                return False, holder
+            except (OSError, ProcessLookupError):
+                pass  # stale lock; reclaim below
+        except (OSError, ValueError):
+            pass  # garbage; reclaim below
+
+    my_pid = os.getpid()
+    my_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        lock_path.write_text(f"{my_pid}\n{my_time}\n", encoding="utf-8")
+    except OSError as e:
+        return False, f"cannot write {lock_path}: {e}"
+
+    def _release():
+        try:
+            if not lock_path.exists():
+                return
+            content = lock_path.read_text(encoding="utf-8").strip()
+            if content.startswith(str(my_pid)):
+                lock_path.unlink()
+        except Exception:
+            pass
+
+    atexit.register(_release)
+    return True, None
+
+
+def _refuse_concurrent_run(base_dir: Path, holder: str, headless: bool) -> None:
+    """Show the operator a clear "already running" message and exit non-zero."""
+    msg_short = "A processing run is already in progress on this project."
+    msg_detail = (
+        f"Existing run: {holder}\n"
+        f"Lockfile: {base_dir / 'output' / '.pipeline.lock'}\n\n"
+        "Wait for it to finish, or cancel it from the other window, before "
+        "starting another."
+    )
+    if headless:
+        print(f"ERROR: {msg_short}\n{msg_detail}", file=sys.stderr)
+    else:
+        try:
+            app = QApplication.instance() or QApplication(sys.argv)
+            QMessageBox.warning(None, "MESA — Processing already running",
+                                f"{msg_short}\n\n{msg_detail}")
+        except Exception:
+            print(f"ERROR: {msg_short}\n{msg_detail}", file=sys.stderr)
+    sys.exit(2)
+
+
 def main() -> None:
     args = parse_args()
     base_dir = resolve_base_dir(args.original_working_directory)
@@ -2330,6 +2734,14 @@ def main() -> None:
         print("Base dir:", base_dir)
         print("Would run:", ", ".join(selected) if selected else "(nothing)")
         return
+
+    # Single-instance guard: refuse a second concurrent pipeline run for this
+    # project (overlapping runs share one log.txt and one set of parquet
+    # outputs and produce unreadable mixed logs + raced files).
+    acquired, holder = _acquire_pipeline_lock(base_dir)
+    if not acquired:
+        _refuse_concurrent_run(base_dir, holder or "(unknown)", bool(args.headless))
+        return  # _refuse_concurrent_run already called sys.exit; defensive.
 
     if args.headless:
         def log_print(line: str) -> None:

--- a/mesa.py
+++ b/mesa.py
@@ -97,9 +97,10 @@ from PySide6.QtWidgets import (
     QTableWidgetItem, QScrollArea, QFrame, QSizePolicy,
     QMessageBox, QFileDialog, QHeaderView, QSplitter,
     QSpinBox, QDoubleSpinBox, QComboBox, QLineEdit,
+    QDialog,
 )
 from PySide6.QtGui import QPixmap, QIcon, QFont, QFontMetrics, QColor, QPalette, QDesktopServices
-from PySide6.QtCore import Qt, QTimer, QUrl, QSize
+from PySide6.QtCore import Qt, QTimer, QUrl, QSize, QObject, Signal
 
 import subprocess
 import webbrowser
@@ -818,6 +819,15 @@ def edit_lines():
 # ---------------------------------------------------------------------
 # Backup / restore / clear (unchanged logic, Qt dialogs)
 # ---------------------------------------------------------------------
+class _BackupSignals(QObject):
+    """Bridge progress updates from the backup/restore worker thread back to
+    the GUI thread. Always create on the GUI thread so emitted signals are
+    delivered there."""
+    progress = Signal(int, int, str)        # current, total, current_arcname
+    finished = Signal(str)                  # result_path (empty on failure)
+    failed = Signal(str)                    # error message
+
+
 def _iter_backup_files(root_path: Path):
     for dirpath, dirnames, filenames in os.walk(root_path):
         dirnames[:] = [d for d in dirnames if d != "__pycache__"]
@@ -836,12 +846,27 @@ def _safe_zip_member_names(names: list[str]) -> list[str]:
         safe.append("/".join(parts))
     return safe
 
-def create_backup_archive(base_dir: str, destination_path: str) -> str:
+def create_backup_archive(
+    base_dir: str,
+    destination_path: str,
+    *,
+    include_tiles: bool = True,
+    compression_kind: str = "deflate",
+    progress_cb=None,
+) -> str:
     """Create a backup zip at destination_path.
 
     destination_path is the full zip path the caller wants the file written
     to; ``.zip`` is appended if no suffix is present, and parent directories
     are created as needed.
+
+    include_tiles: when False, files under output/mbtiles/ are skipped. Tiles
+    are large (often gigabytes) and fully regenerable from tbl_flat, so users
+    typically don't need them in a backup.
+
+    compression_kind: "deflate" (universal, what zip always supported) or
+    "lzma" (~30-40% smaller on text/parquet, requires modern unzip — Windows
+    Explorer's built-in Extract can't open these; 7-Zip and macOS open them).
     """
     base = Path(base_dir)
     dest = Path(destination_path)
@@ -855,19 +880,43 @@ def create_backup_archive(base_dir: str, destination_path: str) -> str:
     files_to_add: list[tuple[Path, str]] = []
     if config_path.is_file():
         files_to_add.append((config_path, "config.ini"))
+    mbtiles_dir = output_dir / "mbtiles"
+    skipped_tile_count = 0
     for folder in (input_dir, output_dir):
         if folder.is_dir():
             for file_path in _iter_backup_files(folder):
                 if file_path.is_file():
+                    if (not include_tiles
+                            and mbtiles_dir in file_path.parents):
+                        skipped_tile_count += 1
+                        continue
                     arc = file_path.relative_to(base).as_posix()
                     files_to_add.append((file_path, arc))
-    with zipfile.ZipFile(zip_path, mode="w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
-        for file_path, arcname in files_to_add:
-            zf.write(file_path, arcname=arcname)
-    log_to_logfile(f"Created backup archive: {zip_path}")
+
+    if compression_kind == "lzma":
+        zf_kwargs = dict(compression=zipfile.ZIP_LZMA)
+    else:
+        zf_kwargs = dict(compression=zipfile.ZIP_DEFLATED, compresslevel=6)
+    total = len(files_to_add)
+    with zipfile.ZipFile(zip_path, mode="w", **zf_kwargs) as zf:
+        for i, (file_path, arcname) in enumerate(files_to_add, start=1):
+            # Per-entry override is needed because ZIP_LZMA isn't valid as a
+            # default in older Python tarballs; passing it via write keeps
+            # us safe across versions.
+            zf.write(file_path, arcname=arcname, compress_type=zf_kwargs["compression"])
+            if progress_cb is not None:
+                try:
+                    progress_cb(i, total, arcname)
+                except Exception:
+                    pass  # never let a UI callback break the backup
+    if skipped_tile_count:
+        log_to_logfile(f"Created backup archive: {zip_path} "
+                       f"(tiles excluded: {skipped_tile_count} file(s))")
+    else:
+        log_to_logfile(f"Created backup archive: {zip_path}")
     return str(zip_path)
 
-def restore_backup_archive(base_dir: str, zip_path: str) -> None:
+def restore_backup_archive(base_dir: str, zip_path: str, *, progress_cb=None) -> None:
     base = Path(base_dir)
     zip_file = Path(zip_path)
     if not zip_file.is_file():
@@ -888,7 +937,8 @@ def restore_backup_archive(base_dir: str, zip_path: str) -> None:
                 cfg.unlink()
             except Exception:
                 pass
-        for member in to_extract:
+        total = len(to_extract)
+        for i, member in enumerate(to_extract, start=1):
             target = (base / Path(member)).resolve()
             base_resolved = base.resolve()
             if target != base_resolved and base_resolved not in target.parents:
@@ -896,6 +946,11 @@ def restore_backup_archive(base_dir: str, zip_path: str) -> None:
             target.parent.mkdir(parents=True, exist_ok=True)
             with zf.open(member, "r") as src, open(target, "wb") as dst:
                 shutil.copyfileobj(src, dst)
+            if progress_cb is not None:
+                try:
+                    progress_cb(i, total, member)
+                except Exception:
+                    pass
     check_and_create_folders()
     log_to_logfile(f"Restored backup archive: {zip_file}")
 
@@ -2945,13 +3000,126 @@ class MesaMainWindow(QMainWindow):
 
         self._main_layout.addWidget(self._tabs, stretch=1)
 
+        self._build_welcome_tab()
         self._build_workflows_tab()
         self._build_status_tab()
         self._build_manage_tab()
         self._build_config_tab()
         self._build_about_tab()
 
-    # ---- Tab 1: Workflows ----
+    # ---- Tab 1: Welcome ----
+    def _project_info_path(self):
+        return os.path.join(
+            original_working_directory, "output", "geoparquet", "tbl_project_info.parquet"
+        )
+
+    def _read_project_info(self):
+        path = self._project_info_path()
+        blank = {"project_name": "", "about": "", "updated_utc": ""}
+        if not os.path.exists(path):
+            return blank
+        try:
+            df = pd.read_parquet(path)
+            if df.empty:
+                return blank
+            row = df.iloc[0]
+            return {
+                "project_name": str(row.get("project_name", "") or ""),
+                "about": str(row.get("about", "") or ""),
+                "updated_utc": str(row.get("updated_utc", "") or ""),
+            }
+        except Exception:
+            return blank
+
+    def _save_project_info(self):
+        path = self._project_info_path()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        now_utc = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+        row = {
+            "project_name": self._project_name_edit.text().strip(),
+            "about": self._project_about_edit.toPlainText().strip(),
+            "updated_utc": now_utc,
+        }
+        try:
+            pd.DataFrame([row]).to_parquet(path, index=False)
+            self._project_info_status.setText(f"Last saved: {now_utc}")
+            self._project_continue_btn.setVisible(True)
+        except Exception as e:
+            QMessageBox.warning(self, "Save failed", f"Could not save project info:\n{e}")
+
+    def _build_welcome_tab(self):
+        tab = QWidget()
+        layout = QVBoxLayout(tab)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(12)
+
+        intro_group = QGroupBox("Welcome to MESA")
+        intro_layout = QVBoxLayout(intro_group)
+        intro_text = QLabel(
+            "MESA (Method for an Easy Sensitivity Assessment) helps you run a complete "
+            "sensitivity assessment on your own machine: import spatial data, configure "
+            "the analysis, run the processing pipeline, and produce maps and reports. "
+            "All data stays local — nothing is uploaded to external services.\n\n"
+            "Use the tabs above to move through the workflow. Start by giving this "
+            "project a name and a short description below."
+        )
+        intro_text.setWordWrap(True)
+        intro_layout.addWidget(intro_text)
+        layout.addWidget(intro_group)
+
+        form_group = QGroupBox("This project")
+        form_layout = QVBoxLayout(form_group)
+        form_layout.setSpacing(8)
+
+        name_row = QHBoxLayout()
+        name_label = QLabel("Project name:")
+        name_label.setMinimumWidth(120)
+        self._project_name_edit = QLineEdit()
+        self._project_name_edit.setPlaceholderText("e.g. North Sea Wind Farm 2026")
+        name_row.addWidget(name_label)
+        name_row.addWidget(self._project_name_edit, stretch=1)
+        form_layout.addLayout(name_row)
+
+        about_label = QLabel("About this project:")
+        form_layout.addWidget(about_label)
+        self._project_about_edit = QPlainTextEdit()
+        self._project_about_edit.setPlaceholderText(
+            "A short description of the area, scope, stakeholders, or anything that helps "
+            "you and collaborators remember what this project is about."
+        )
+        form_layout.addWidget(self._project_about_edit, stretch=1)
+
+        button_row = QHBoxLayout()
+        save_btn = QPushButton("Save")
+        save_btn.setProperty("role", "primary")
+        save_btn.clicked.connect(self._save_project_info)
+        self._project_info_status = QLabel("")
+        self._project_info_status.setStyleSheet("color: #6e5a37; font-size: 9pt;")
+        self._project_continue_btn = QPushButton("Continue to Workflows →")
+        self._project_continue_btn.setProperty("role", "success")
+        self._project_continue_btn.setVisible(False)
+        self._project_continue_btn.clicked.connect(
+            lambda: self._tabs.setCurrentWidget(self._tabs.widget(1))
+        )
+        button_row.addWidget(save_btn)
+        button_row.addSpacing(12)
+        button_row.addWidget(self._project_info_status)
+        button_row.addStretch()
+        button_row.addWidget(self._project_continue_btn)
+        form_layout.addLayout(button_row)
+
+        layout.addWidget(form_group, stretch=1)
+
+        info = self._read_project_info()
+        self._project_name_edit.setText(info["project_name"])
+        self._project_about_edit.setPlainText(info["about"])
+        if info["updated_utc"]:
+            self._project_info_status.setText(f"Last saved: {info['updated_utc']}")
+            self._project_continue_btn.setVisible(True)
+
+        self._tabs.addTab(tab, "Welcome")
+
+    # ---- Tab 2: Workflows ----
     def _build_workflows_tab(self):
         tab = QWidget()
         layout = QVBoxLayout(tab)
@@ -4097,9 +4265,81 @@ class MesaMainWindow(QMainWindow):
         layout.addStretch()
         self._tabs.addTab(tab, "Manage data")
 
+    def _ask_backup_options(self):
+        """Show a small modal dialog with backup options.
+
+        Returns (include_tiles: bool, compression_kind: str) or None if the
+        user cancelled.
+        """
+        dlg = QDialog(self)
+        dlg.setWindowTitle("Backup options")
+        dlg.setModal(True)
+        layout = QVBoxLayout(dlg)
+        layout.setContentsMargins(16, 16, 16, 12)
+        layout.setSpacing(10)
+
+        intro = QLabel(
+            "Choose what to include in the backup and how to compress it."
+        )
+        intro.setWordWrap(True)
+        layout.addWidget(intro)
+
+        tiles_cb = QCheckBox("Include rendered tiles (output/mbtiles/)")
+        tiles_cb.setChecked(True)
+        tiles_hint = QLabel(
+            "Tiles are large (often gigabytes) and can be regenerated from "
+            "tbl_flat. Uncheck to keep the backup small."
+        )
+        tiles_hint.setWordWrap(True)
+        tiles_hint.setStyleSheet("color: #6a5533; font-size: 9pt;")
+        layout.addWidget(tiles_cb)
+        layout.addWidget(tiles_hint)
+
+        layout.addSpacing(4)
+
+        fmt_label = QLabel("Compression:")
+        layout.addWidget(fmt_label)
+        fmt_combo = QComboBox()
+        fmt_combo.addItem("Compatible (.zip, DEFLATE)", userData="deflate")
+        fmt_combo.addItem("Smaller (.zip, LZMA)", userData="lzma")
+        layout.addWidget(fmt_combo)
+        fmt_hint = QLabel(
+            "LZMA produces a ~30-40% smaller archive on text + parquet data. "
+            "Modern unzip tools (7-Zip on Windows, macOS, Linux) open it. "
+            "Windows Explorer's built-in Extract does NOT — pick Compatible "
+            "if recipients only have that."
+        )
+        fmt_hint.setWordWrap(True)
+        fmt_hint.setStyleSheet("color: #6a5533; font-size: 9pt;")
+        layout.addWidget(fmt_hint)
+
+        layout.addStretch()
+
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+        cancel_btn = QPushButton("Cancel")
+        ok_btn = QPushButton("Continue…")
+        ok_btn.setProperty("role", "primary")
+        ok_btn.setDefault(True)
+        cancel_btn.clicked.connect(dlg.reject)
+        ok_btn.clicked.connect(dlg.accept)
+        btn_row.addWidget(cancel_btn)
+        btn_row.addWidget(ok_btn)
+        layout.addLayout(btn_row)
+
+        dlg.resize(420, dlg.sizeHint().height())
+        if dlg.exec() != QDialog.Accepted:
+            return None
+        return bool(tiles_cb.isChecked()), str(fmt_combo.currentData())
+
     def _do_backup(self):
-        # Suggest a timestamped filename but let the user revise both folder
-        # and name in a single Save-As dialog.
+        # Step 1: collect options (tiles + compression) before asking where to save.
+        opts = self._ask_backup_options()
+        if opts is None:
+            return  # user cancelled
+        include_tiles, compression_kind = opts
+
+        # Step 2: file dialog for save path.
         ts = datetime.now().strftime("%Y-%m-%d_%H%M%S")
         default_name = f"mesa_backup_{ts}.zip"
         default_path = os.path.join(original_working_directory, default_name)
@@ -4114,28 +4354,36 @@ class MesaMainWindow(QMainWindow):
         if not chosen_path.lower().endswith(".zip"):
             chosen_path += ".zip"
 
-        # Show progress dialog (backup can be slow for large projects)
-        progress = QProgressDialog("Creating backup archive...", None, 0, 0, self)
+        # The backup runs on a worker thread so the GUI (and macOS Finder
+        # previews of the growing .zip) stays responsive. LZMA in particular
+        # can take many seconds per file on the GUI thread.
+        progress = QProgressDialog(
+            "Preparing backup…", None, 0, 0, self
+        )
         progress.setWindowTitle("Backup in progress")
         progress.setMinimumDuration(0)
         progress.setWindowModality(Qt.WindowModal)
         progress.setCancelButton(None)
+        progress.setAutoClose(False)
+        progress.setAutoReset(False)
         progress.show()
-        QApplication.processEvents()
 
-        result_path = None
-        error_msg = None
-        try:
-            result_path = create_backup_archive(original_working_directory, chosen_path)
-        except Exception as e:
-            error_msg = str(e)
+        signals = _BackupSignals()
 
-        progress.close()
+        def _on_progress(current: int, total: int, arcname: str) -> None:
+            # First tick switches the dialog from busy spinner to a real bar.
+            if progress.maximum() != total:
+                progress.setRange(0, total)
+            progress.setValue(current)
+            # Show just the file leaf so the dialog doesn't grow horizontally
+            # on deep paths.
+            leaf = arcname.rsplit("/", 1)[-1]
+            progress.setLabelText(
+                f"Archiving file {current:,} of {total:,}…\n{leaf}"
+            )
 
-        if error_msg:
-            self._manage_status.setText(f"Backup failed: {error_msg}")
-            QMessageBox.critical(self, "Backup failed", error_msg)
-        else:
+        def _on_finished(result_path: str) -> None:
+            progress.close()
             fname = os.path.basename(result_path) if result_path else "backup"
             fdir = os.path.dirname(result_path) if result_path else ""
             try:
@@ -4148,6 +4396,29 @@ class MesaMainWindow(QMainWindow):
                                     f"Backup saved successfully.\n\n"
                                     f"File: {fname}\n"
                                     f"Location: {fdir}{size_str}")
+
+        def _on_failed(error_msg: str) -> None:
+            progress.close()
+            self._manage_status.setText(f"Backup failed: {error_msg}")
+            QMessageBox.critical(self, "Backup failed", error_msg)
+
+        signals.progress.connect(_on_progress)
+        signals.finished.connect(_on_finished)
+        signals.failed.connect(_on_failed)
+
+        def _worker():
+            try:
+                result_path = create_backup_archive(
+                    original_working_directory, chosen_path,
+                    include_tiles=include_tiles,
+                    compression_kind=compression_kind,
+                    progress_cb=lambda i, n, a: signals.progress.emit(i, n, a),
+                )
+                signals.finished.emit(result_path)
+            except Exception as e:
+                signals.failed.emit(str(e))
+
+        threading.Thread(target=_worker, daemon=True).start()
 
     def _do_restore(self):
         zip_path, _ = QFileDialog.getOpenFileName(
@@ -4166,26 +4437,28 @@ class MesaMainWindow(QMainWindow):
         if confirm != QMessageBox.Yes:
             return
 
-        progress = QProgressDialog("Restoring backup archive...", None, 0, 0, self)
+        progress = QProgressDialog("Preparing restore…", None, 0, 0, self)
         progress.setWindowTitle("Restore in progress")
         progress.setMinimumDuration(0)
         progress.setWindowModality(Qt.WindowModal)
         progress.setCancelButton(None)
+        progress.setAutoClose(False)
+        progress.setAutoReset(False)
         progress.show()
-        QApplication.processEvents()
 
-        error_msg = None
-        try:
-            restore_backup_archive(original_working_directory, zip_path)
-        except Exception as e:
-            error_msg = str(e)
+        signals = _BackupSignals()
 
-        progress.close()
+        def _on_progress(current: int, total: int, member: str) -> None:
+            if progress.maximum() != total:
+                progress.setRange(0, total)
+            progress.setValue(current)
+            leaf = member.rsplit("/", 1)[-1]
+            progress.setLabelText(
+                f"Restoring file {current:,} of {total:,}…\n{leaf}"
+            )
 
-        if error_msg:
-            self._manage_status.setText(f"Restore failed: {error_msg}")
-            QMessageBox.critical(self, "Restore failed", error_msg)
-        else:
+        def _on_finished(_unused: str) -> None:
+            progress.close()
             self._manage_status.setText(f"Backup restored: {zip_path}")
             QMessageBox.information(self, "Restore completed",
                                     "Backup restore completed successfully.")
@@ -4193,6 +4466,27 @@ class MesaMainWindow(QMainWindow):
                 self._refresh_status_tab()
             except Exception:
                 pass
+
+        def _on_failed(error_msg: str) -> None:
+            progress.close()
+            self._manage_status.setText(f"Restore failed: {error_msg}")
+            QMessageBox.critical(self, "Restore failed", error_msg)
+
+        signals.progress.connect(_on_progress)
+        signals.finished.connect(_on_finished)
+        signals.failed.connect(_on_failed)
+
+        def _worker():
+            try:
+                restore_backup_archive(
+                    original_working_directory, zip_path,
+                    progress_cb=lambda i, n, m: signals.progress.emit(i, n, m),
+                )
+                signals.finished.emit("")
+            except Exception as e:
+                signals.failed.emit(str(e))
+
+        threading.Thread(target=_worker, daemon=True).start()
 
     def _do_clear_output(self):
         output_dir = os.path.join(original_working_directory, "output")


### PR DESCRIPTION
mesa.py
  - Welcome tab as first tab: project name + about text persisted to output/geoparquet/tbl_project_info.parquet, with a "Continue to Workflows →" CTA that appears after Save.
  - Backup options dialog (include-tiles toggle + DEFLATE/LZMA selector).
  - Backup/restore moved to a worker thread with per-file progress signals so the GUI (and Finder previews of the growing zip) stay responsive on multi-GB archives.

code/processing_pipeline_run.py
  - Single-instance pipeline lock at output/.pipeline.lock, PID-checked with stale-lock reclaim. Refuses overlapping runs that previously interleaved log.txt and raced parquet outputs.
  - Cancel actually stops the pipeline mid-flight: a subprocess watchdog in _run_subprocess_streaming terminates the tiles helper, and an inter-stage gate in run_selected() raises ProcessingCancelled between stages so follow-on work does not start after a cancel.
  - Distinct "RUN CANCELLED" terminal state in the UI with the progress bar reset to zero and a clear marker line in the log.
  - Stale output/mbtiles/ wiped at run start when Tiles is unchecked, with an in-UI warning next to the checkbox so the deletion is not silent.
  - Self-calibrating progress weights: tbl_stage_runtime.parquet records per-stage durations for each run, and the next run averages the last five clean completions to allocate the progress bar proportionally. Cancelled/errored rows are excluded from the average. Falls back to realistic defaults on first run (tiles weighted heaviest, not lightest as in the previous static table).
  - Process button reads "Processing…" while a run is active.

code/processing_internal.py
  - All seven parquet write sites switched from SNAPPY to ZSTD level 3. Benchmark on existing tbl_stacked shows ~2x smaller partitions on large files; ~1.2x on small ones. Read paths unchanged (pyarrow decodes both transparently).